### PR TITLE
ナビゲーションバー作成

### DIFF
--- a/my-app/src/component/Navbar/Navbar.stories.tsx
+++ b/my-app/src/component/Navbar/Navbar.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Navbar from "./Navbar";
+
+const meta = {
+  component: Navbar,
+  args: { navPages: ["aaa", "bbb", "ccc"] },
+} satisfies Meta<typeof Navbar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/component/Navbar/Navbar.tsx
+++ b/my-app/src/component/Navbar/Navbar.tsx
@@ -1,0 +1,101 @@
+import { Box, Breadcrumbs, ButtonBase, Link, Typography } from "@mui/material";
+import { NavBarLogic } from "./logic";
+
+type Props = {
+  /** 移動元のページ順番 */
+  navPages: string[];
+};
+
+/**
+ *  ナビゲーションバーの共通コンポーネント
+ */
+export default function Navbar({ navPages }: Props) {
+  const { isLastPageIndex, getLink } = NavBarLogic({ navPages });
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        overflow: "hidden",
+        color: "white",
+        padding: 5,
+      }}
+    >
+      {/* 左の四角形エリア */}
+      <Box
+        sx={{
+          flex: "0 0 60%", // 全体の70%を占める
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 2,
+          background:
+            "linear-gradient(to right, rgb(255, 255, 255), rgb(220, 220, 220))",
+          borderBottom: "1px solid #ccc",
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        {/** ナビゲーション部分 */}
+        <Breadcrumbs separator="›" aria-label="breadcrumb">
+          {navPages.map((navPage, index) => {
+            {
+              /** 最後の場合(現在開いているページ)ではリンクの代わりにTypographyを表示 */
+            }
+            if (isLastPageIndex(index)) {
+              return (
+                <Typography key={navPage} sx={{ color: "text.primary" }}>
+                  {navPage}
+                </Typography>
+              );
+            } else {
+              {
+                /** ページのリンクを表示する */
+              }
+              return (
+                <ButtonBase
+                  key={navPage}
+                  component={Link}
+                  href={getLink(navPages, index)}
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    borderRadius: "50%",
+                    overflow: "hidden", // リップルがはみ出さないように
+                    transition: "background-color 0.2s, transform 0.1s",
+                    "&:hover": {
+                      backgroundColor: "rgba(0, 0, 0, 0.08)",
+                    },
+                    "&:active": {
+                      backgroundColor: "rgba(0, 0, 0, 0.12)",
+                      transform: "scale(0.98)", // 押し込む感じ
+                    },
+                  }}
+                >
+                  <Link
+                    key={navPage}
+                    underline="hover"
+                    color="inherit"
+                    href={getLink(navPages, index)}
+                  >
+                    {navPage}
+                  </Link>
+                </ButtonBase>
+              );
+            }
+          })}
+        </Breadcrumbs>
+      </Box>
+      {/* 右の三角形エリア */}
+      <Box
+        sx={{
+          flex: "0 0 40%", // 残り30%
+          background:
+            "linear-gradient(to right, rgb(220, 220, 220), rgb(117, 117, 117))",
+          clipPath: "polygon(0 0, 100% 0, 0 100%)", // 右側が尖る三角形
+          borderBottom: "1px solid #ccc",
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+        }}
+      />
+    </Box>
+  );
+}

--- a/my-app/src/component/Navbar/logic.ts
+++ b/my-app/src/component/Navbar/logic.ts
@@ -1,0 +1,24 @@
+type Props = {
+  /** 移動元のページ順番 */
+  navPages: string[];
+};
+
+/**
+ * NavBarコンポーネントのロジック部分
+ */
+export const NavBarLogic = ({ navPages }: Props) => {
+  const isLastPageIndex = (index: number): boolean =>
+    navPages.length - 1 == index;
+
+  const getLink = (pageNames: string[], index: number): string => {
+    const result: string[] = ["/"];
+    for (let i = 0; i <= index; i++) {
+      result.push(pageNames[i]);
+    }
+    return result.join("/");
+  };
+  return {
+    isLastPageIndex,
+    getLink,
+  };
+};


### PR DESCRIPTION
# 変更点
- ナビゲーションバーのコンポーネントを作成

# 実装の詳細
## 外枠
- MUIのBOXにcssを適応して作成(cssファイルは個別で作成せず、MUI提供のfxプロパティを使用)
- 四角のコンテンツ部分とデザイン用の三角のパーツを組み合わせて作成
- グラデーションを設定して一つの箱に見えるように設定
## コンテンツ
- デザイン
  - MUIのBreadcrumbsを利用してナビゲーションを作成(<a href=https://mui.com/material-ui/react-breadcrumbs/#custom-separator>詳細</a>)
  - MUIのButtonBaseを利用してリンクにアニメーションを設定
- 機能
  - 現在のページまでのルートをnavPages:string[]形式で受け取り[0]/[1]/[2]のようにリンクを形成
    - 今後の実装でリンクに変更がある場合、修正する可能性があります。
  - 現在のルート以外はLinkを親とするButtonBaseになっており、クリックすることで対象のページへ移動が可能
  - 現在のルートはTypographyに設定されており、リンクされない