### PR TITLE
UI:日付ページ　テーブル　ヘッダー作成

### DIFF
--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.stories.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import DailyTableHeader from "./DailyTableHeader";
+
+const meta = {
+  component: DailyTableHeader,
+  args: {
+    isAsc: true,
+    OnClickTitle: () => {},
+    OnHoverTitle: () => {},
+    OnLeaveHoverTitle: () => {},
+  },
+} satisfies Meta<typeof DailyTableHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isSelected: () => false,
+  },
+};
+export const Selected: Story = {
+  args: { isSelected: () => true },
+};
+export const Desc: Story = {
+  args: { isAsc: false, isSelected: () => true },
+};

--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
@@ -1,0 +1,67 @@
+import {
+  ButtonBase,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+} from "@mui/material";
+import { DailyTableHeaderLogic } from "./logic";
+
+type Props = {
+  /** 昇順かどうか */
+  isAsc: boolean;
+  /** 項目が選択中かどうか */
+  isSelected: (title: string) => boolean;
+  /** 表題をクリックした際のハンドラー */
+  OnClickTitle: (title: string) => void;
+  /** 表題にホバーした際のハンドラー */
+  OnHoverTitle: (title: string) => void;
+  /** 表題のホバーを解除した際のハンドラー */
+  OnLeaveHoverTitle: (title: string) => void;
+};
+
+/** 日ごとの一覧ページのテーブルコンポーネントのヘッダー部分 */
+export default function DailyTableHeader({
+  isAsc,
+  isSelected,
+  OnClickTitle,
+  OnHoverTitle,
+  OnLeaveHoverTitle,
+}: Props) {
+  const { tableTitles } = DailyTableHeaderLogic();
+  return (
+    <TableHead>
+      <TableRow>
+        {tableTitles.map((title) => (
+          <TableCell key={title} sx={{ padding: "16px 24px", minWidth: 150 }}>
+            <ButtonBase
+              onClick={() => OnClickTitle(title)}
+              onMouseEnter={() => OnHoverTitle(title)}
+              onMouseLeave={() => OnLeaveHoverTitle(title)}
+              sx={{
+                display: "inline-flex", // ラベルの大きさに合わせる
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "16px", // 楕円っぽい形
+                padding: "4px 12px",
+                transition: "background-color 0.2s",
+                backgroundColor: isSelected(title)
+                  ? "rgba(0, 0, 0, 0.07)"
+                  : "transparent",
+                "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.1)" }, // ホバー時にグレー
+                "&:active": { backgroundColor: "rgba(0, 0, 0, 0.2)" }, // クリック時に濃いグレー
+              }}
+            >
+              <TableSortLabel
+                active={isSelected(title)}
+                direction={isSelected(title) && !isAsc ? "desc" : "asc"}
+              >
+                {title}
+              </TableSortLabel>
+            </ButtonBase>
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}

--- a/my-app/src/pages/work-log/daily/table/header/logic.ts
+++ b/my-app/src/pages/work-log/daily/table/header/logic.ts
@@ -1,0 +1,16 @@
+/**
+ * 日付ページのテーブルコンポーネントのヘッダーのロジック
+ */
+export const DailyTableHeaderLogic = () => {
+  const tableTitles: string[] = [
+    "日付",
+    "メインカテゴリ",
+    "メインタスク",
+    "メモ",
+    "合計稼働時間",
+  ];
+  return {
+    /** テーブルのタイトル一覧 */
+    tableTitles,
+  };
+};


### PR DESCRIPTION
# 変更点
- 日付ページのテーブルのヘッダーUIを作成

# 詳細
## デザイン
- MUIのTableで作成 
- TableSortLabelを使うことでプレイヤーの操作に応じてソートアイコンが表示可能
- ButtonBaseを使うことでクリック可能でレスポンスのあるデザインに作成
## 機能
- 親からのプロパティに応じて表示を変更可能
  - 選択状態になるとTableSortLabelのactiveプロパティが変化して対象のソートアイコンが常時表示状態に変更
  - 変更先が昇順/降順かに応じてソートアイコンを切り替えられる