### PR TITLE
ui:タイトルだけ表示するMenuContentUI作成

### DIFF
--- a/my-app/src/component/menu/content/CustomMenuTitle/CustomMenuTitle.stories.tsx
+++ b/my-app/src/component/menu/content/CustomMenuTitle/CustomMenuTitle.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import CustomMenuTitle from "./CustomMenuTitle";
+
+const meta = {
+  component: CustomMenuTitle,
+  args: {
+    titleList: ["title1", "title2", "title3"],
+  },
+} satisfies Meta<typeof CustomMenuTitle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/my-app/src/component/menu/content/CustomMenuTitle/CustomMenuTitle.tsx
+++ b/my-app/src/component/menu/content/CustomMenuTitle/CustomMenuTitle.tsx
@@ -1,0 +1,18 @@
+import { Divider, Typography } from "@mui/material";
+import React from "react";
+
+type Props = {
+  /** タイトル名の配列 */
+  titleList: string[];
+};
+/**
+ * タイトルの表示のみをするカスタムメニューコンポーネントのコンテンツコンポーネント
+ */
+export default function CustomMenuTitle({ titleList }: Props) {
+  return titleList.map((title, index) => (
+    <React.Fragment key={title}>
+      <Typography padding={1}>{title}</Typography>
+      {index < titleList.length - 1 && <Divider />}
+    </React.Fragment>
+  ));
+}


### PR DESCRIPTION
# 実装概要
- タイトルだけを表示するコンテンツ CustomMenuTitleコンポーネントを作成
# 詳細
- Typographyを用いてコンテンツのタイトルを表示
- Dividerを用いて区切りを作成