### PR TITLE
fix:コンソールエラー

### DIFF
--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.stories.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import DailyTableHeader from "./DailyTableHeader";
+import { Table } from "@mui/material";
 
 const meta = {
   component: DailyTableHeader,
@@ -10,6 +11,13 @@ const meta = {
     onHoverTitle: () => {},
     onLeaveHoverTitle: () => {},
   },
+  decorators: [
+    (StoryComponent) => (
+      <Table>
+        <StoryComponent />
+      </Table>
+    ),
+  ],
 } satisfies Meta<typeof DailyTableHeader>;
 
 export default meta;


### PR DESCRIPTION
# 修正概要
- Storybook上のtheadがdivに囲まれている旨のエラーを修正
# 詳細
- theadを元に作成されたMUIのTableHeaderを親の構造として設定した場合のエラー
  - 実際にはdivでは囲まれていないが、Tableで囲まれていないためエラーが表示される

元コードはテーブル実装時にTableで囲むため、問題なし。
Storybook上ではデコレーターを用いてTableで囲むことで修正