### PR TITLE
refactor:テーブル全体で設定するため、ヘッダーのレイアウト部分を削除

### DIFF
--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
@@ -37,7 +37,7 @@ export default function DailyTableHeader({
       <TableRow>
         {Object.entries(headerColumnDisplay).map(([title, type]) => (
           // 共通設定(パディングやサイズなど)
-          <TableCell key={title} sx={{ padding: "16px 24px", minWidth: 150 }}>
+          <TableCell key={title}>
             {/** メニューを表示しない場合(日付・合計稼働時間) */}
             {type == "none" && (
               <ButtonBase


### PR DESCRIPTION
# 変更点
- DailyTableHeaderのレイアウトのプロパティを削除

# 詳細
- DailyTable実装時に全体のレイアウトを設定するため、削除
- 重複部分が生まれるため