### PR TITLE
ui:日付ページテーブルのデザイン作成

### DIFF
--- a/my-app/src/dummy/daily-page.ts
+++ b/my-app/src/dummy/daily-page.ts
@@ -1,0 +1,73 @@
+import { DateSummary } from "@/type/Date";
+
+/**
+ * 日付ページ一覧ページ用のダミーデータ
+ */
+export const DUMMY_DAILY_SUMMARY_DATA: DateSummary[] = [
+  {
+    id: 0,
+    categoryName: "カテゴリ1",
+    date: new Date("2025-01-24"),
+    taskName: "タスク1",
+    memo: [
+      {
+        id: 0,
+        title: "メモ1",
+        date: new Date("2025-01-24"),
+        taskName: "タスク1",
+      },
+    ],
+    dailyHours: 8,
+  },
+  {
+    id: 1,
+    categoryName: "カテゴリ2",
+    date: new Date("2025-01-26"),
+    taskName: "タスク2",
+    memo: [
+      {
+        id: 0,
+        title: "メモ1",
+        date: new Date("2025-01-26"),
+        taskName: "タスク2",
+      },
+    ],
+    dailyHours: 8,
+  },
+  {
+    id: 2,
+    categoryName: "カテゴリ3",
+    date: new Date("2025-01-29"),
+    taskName: "タスク3",
+    memo: [
+      {
+        id: 0,
+        title: "メモ1",
+        date: new Date("2025-01-29"),
+        taskName: "タスク3",
+      },
+    ],
+    dailyHours: 8,
+  },
+  {
+    id: 4,
+    categoryName: "カテゴリ1",
+    date: new Date("2025-02-12"),
+    taskName: "タスク1",
+    memo: [
+      {
+        id: 0,
+        title: "メモ1",
+        date: new Date("2025-02-12"),
+        taskName: "タスク1",
+      },
+      {
+        id: 1,
+        title: "メモ2",
+        date: new Date("2025-02-12"),
+        taskName: "タスク2",
+      },
+    ],
+    dailyHours: 8,
+  },
+];

--- a/my-app/src/pages/work-log/daily/table/DailyTable.stories.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import DailyTable from "./DailyTable";
+import { DUMMY_DAILY_SUMMARY_DATA } from "@/dummy/daily-page";
+
+const meta = {
+  component: DailyTable,
+  args: { itemList: DUMMY_DAILY_SUMMARY_DATA },
+} satisfies Meta<typeof DailyTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/my-app/src/pages/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.tsx
@@ -1,0 +1,125 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import DailyTableLogic from "./logic";
+import DailyTableHeader from "./header/DailyTableHeader";
+import { DateSummary } from "@/type/Date";
+import { format } from "date-fns";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+
+type Props = {
+  /** アイテム */
+  itemList: DateSummary[];
+};
+/**
+ * 日付ページのテーブルコンポーネント
+ */
+export default function DailyTable({ itemList }: Props) {
+  const { isAsc, isSelected, handleSort } = DailyTableLogic();
+  return (
+    <TableContainer>
+      <Table sx={{ width: "100%", padding: "16px 24px" }}>
+        <DailyTableHeader
+          isAsc={isAsc}
+          isSelected={isSelected}
+          OnClickTitle={handleSort}
+          onHoverTitle={() => {}} // TODO:展開機能追加時に追記
+          onLeaveHoverTitle={() => {}} // TODO:展開機能追加時に追記
+        />
+        <TableBody>
+          {itemList.map((item) => (
+            <TableRow
+              key={item.id}
+              hover
+              onClick={() => {}}
+              sx={{
+                cursor: "pointer",
+              }}
+            >
+              {/** 日付 */}
+              <TableCell
+                sx={{
+                  maxWidth: "150px", // 幅
+                  width: "150px", // 幅
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <Typography>{format(item.date, "yyyy-MM-dd")}</Typography>
+              </TableCell>
+              {/** メインカテゴリ */}
+              <TableCell
+                sx={{
+                  maxWidth: "150px", // 幅
+                  width: "150px", // 幅
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {item.categoryName}
+              </TableCell>
+              {/** メインタスク */}
+              <TableCell
+                sx={{
+                  maxWidth: "150px", // 幅
+                  width: "150px", // 幅
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {item.taskName}
+              </TableCell>
+              {/** メモ(0番目のめもを表示)  TODO:展開できるようにする*/}
+              <TableCell
+                sx={{
+                  maxWidth: "150px", // 幅
+                  width: "150px", // 幅
+                  gap: 2,
+                  borderRadius: "4px",
+                  transition: "background 0.5s",
+                  "&:hover": { backgroundColor: "rgba(31, 158, 255, 0.37)" },
+                }}
+              >
+                <Typography
+                  sx={{
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {item.memo[0].title}
+                </Typography>
+                <KeyboardArrowDownIcon
+                  sx={{
+                    opacity: 0.6,
+                    fontSize: 20,
+                  }}
+                />
+              </TableCell>
+              {/** 稼働合計 */}
+              <TableCell
+                sx={{
+                  maxWidth: "150px", // 幅
+                  width: "150px", // 幅
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <Typography>{item.dailyHours}</Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/my-app/src/pages/work-log/daily/table/logic.ts
+++ b/my-app/src/pages/work-log/daily/table/logic.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+/**
+ * 日ごとの一覧ページのテーブルコンポーネントのロジック部分
+ */
+export default function DailyTableLogic() {
+  const [selected, setSelected] = useState<string>("日付");
+  const [isAsc, setIsAsc] = useState<boolean>(true);
+
+  // 該当するタイトルが選択中か調べる
+  const isSelected = useCallback(
+    (title: string): boolean => title == selected,
+    [selected]
+  );
+
+  // プロパティをソート設定する関数
+  const handleSort = useCallback(
+    (title: string): void => {
+      // 選択中の場合:ascとdescを入れ替える
+      if (isSelected(title)) {
+        setIsAsc(!isAsc);
+      } else {
+        setSelected(title);
+        setIsAsc(true);
+      }
+    },
+    [isAsc, isSelected]
+  );
+
+  return {
+    /** 現在昇順かどうか */
+    isAsc,
+    /** 選択中かどうか調べる関数 */
+    isSelected,
+    /** ソートする関数 */
+    handleSort,
+  };
+}


### PR DESCRIPTION
# 概要
- テーブルのUIを作成
- ヘッダー選択時のソートのUIの切り替えロジックを実装

# 詳細
- DailyTableHeaderをヘッダーに持つ
- body部分は各列ごとクリック可能
- メモ部分はホバーすると色が変更させる
- セル幅は150pxで固定され、文字数が多い場合は「...」で省略

# 注意事項
- 特定の項目にホバー時に表示されるカスタムメニューのUIについて
  - ロジック作成時に組み込みを行うため、その時に適宜調整する予定