### PR TITLE
feature:テーブルの操作とメニュー操作を両立できるように更新

### DIFF
--- a/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapper.tsx
+++ b/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapper.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@mui/material";
+import { Fade, Paper, Popper } from "@mui/material";
 import CustomMenuWrapperLogic from "./CustomMenuWrapperLogic";
 import { ReactNode } from "react";
 
@@ -13,18 +13,18 @@ type Props = {
  * ホバー時/クリック時などで表示する選択のポップアップコンポーネント
  */
 export default function CustomMenuWrapper({ children, logic }: Props) {
-  const { open, anchorEl, handleClose, handleMouseEnter, handleMouseLeave } =
-    logic;
+  const { open, anchorEl, handleMouseEnter, handleMouseLeave } = logic;
   return (
-    <Menu
+    <Popper
       id="basic-menu"
       anchorEl={anchorEl}
       open={open}
-      onClose={handleClose}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {children}
-    </Menu>
+      <Fade in={open} timeout={500}>
+        <Paper>{children}</Paper>
+      </Fade>
+    </Popper>
   );
 }


### PR DESCRIPTION
# 変更点
- Menuコンポーネント ->Popperコンポーネントに変更
- それに伴いMenuが内包していた枠組みやアニメーションのコンポーネントを別途追加
# 詳細
- 実装の参考について <a href=https://mui.com/material-ui/react-menu/#composition-with-menu-list>MUIサンプル</a>
- テーブルを開いている最中にメニューを表示する場合の仕様について
  - Menu及びPopoverの場合はメニューにフォーカスされて閉じるまでテーブルの操作が不可能になる
  - Popperの場合はテーブルの操作も可能
  - 操作が可能である方が今回の実装にはあっているため、変更
- 各おまけのコンポーネントについて
  - Paper 外枠とシャドウの表現
  - Fade フェードインのアニメーションを再現
    - フェードアウトを実装する場合はstate管理が増えるので、保留