### PR TITLE
fix:hover後のタイムアウト後にcurrentTargetを取得できない問題を修正

### DIFF
--- a/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapperLogic.ts
+++ b/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapperLogic.ts
@@ -21,14 +21,11 @@ export default function CustomMenuWrapperLogic() {
   }, []);
 
   // 一定時間後にメニューを開く関数
-  const openAfterTimeout = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      timeoutId.current = setTimeout(() => {
-        setAnchorEl(event.currentTarget);
-      }, timeOutSec);
-    },
-    []
-  );
+  const openAfterTimeout = useCallback((target: HTMLElement) => {
+    timeoutId.current = setTimeout(() => {
+      setAnchorEl(target);
+    }, timeOutSec);
+  }, []);
   // メニューの開閉のタイマーを初期化する関数
   const clearTimeoutTimer = useCallback(() => {
     if (timeoutId.current) {
@@ -49,7 +46,7 @@ export default function CustomMenuWrapperLogic() {
       // メニューが開いていない場合
       // 一定時間後にメニューを開く
     } else {
-      openAfterTimeout(event);
+      openAfterTimeout(event.currentTarget);
     }
   };
 


### PR DESCRIPTION
# 変更点
onMouseEnter呼び出し時にcurrentTargetを取得し、それをtimeout関数に渡すように変更

# 詳細
- 修正前
  - Timeout解決時にcurrentTargetがnullになるため、対象をopenできない
- 修正後
  - MouseEnter時に取得したcurrentTargetを渡すため、対象をopen可能