### PR TITLE
feature:DailyTableの変数追加してロジックを修正

### DIFF
--- a/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapper.tsx
+++ b/my-app/src/component/menu/CustomMenuWrapper/CustomMenuWrapper.tsx
@@ -13,14 +13,20 @@ type Props = {
  * ホバー時/クリック時などで表示する選択のポップアップコンポーネント
  */
 export default function CustomMenuWrapper({ children, logic }: Props) {
-  const { open, anchorEl, handleMouseEnter, handleMouseLeave } = logic;
+  const {
+    open,
+    anchorEl,
+    openTargetIdRef,
+    handleMouseEnter,
+    handleMouseLeave,
+  } = logic;
   return (
     <Popper
       id="basic-menu"
       anchorEl={anchorEl}
       open={open}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onMouseEnter={(e) => handleMouseEnter(openTargetIdRef.current, e)}
+      onMouseLeave={() => handleMouseLeave(openTargetIdRef.current)}
     >
       <Fade in={open} timeout={500}>
         <Paper>{children}</Paper>

--- a/my-app/src/pages/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.tsx
@@ -93,8 +93,8 @@ export default function DailyTable({ itemList }: Props) {
                     transition: "background 0.5s",
                     "&:hover": { backgroundColor: "rgba(31, 158, 255, 0.37)" },
                   }}
-                  onMouseEnter={handleMouseEnter}
-                  onMouseLeave={handleMouseLeave}
+                  onMouseEnter={(e) => handleMouseEnter(item.id, e)}
+                  onMouseLeave={() => handleMouseLeave(item.id)}
                 >
                   <Typography
                     sx={{

--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
@@ -16,9 +16,9 @@ type Props = {
   /** 表題をクリックした際のハンドラー */
   OnClickTitle: (title: string) => void;
   /** セルにホバー時のハンドラー */
-  onHoverTitle: (event: React.MouseEvent<HTMLElement>, title: string) => void;
+  onHoverTitle: (id: number, event: React.MouseEvent<HTMLElement>) => void;
   /** セルにホバー解除時のハンドラー */
-  onLeaveHoverTitle: (title: string) => void;
+  onLeaveHoverTitle: (id: number) => void;
 };
 
 /** 日ごとの一覧ページのテーブルコンポーネントのヘッダー部分 */
@@ -29,9 +29,10 @@ export default function DailyTableHeader({
   isSelected,
   OnClickTitle,
 }: Props) {
-  const { headerColumnDisplay, getButtonDesign } = DailyTableHeaderLogic({
-    isSelected,
-  });
+  const { headerColumnDisplay, getButtonDesign, getPopperIdRef } =
+    DailyTableHeaderLogic({
+      isSelected,
+    });
   return (
     <TableHead>
       <TableRow>
@@ -57,8 +58,10 @@ export default function DailyTableHeader({
             {type == "checkbox" && (
               <ButtonBase
                 onClick={() => OnClickTitle(title)}
-                onMouseEnter={(event) => onHoverTitle(event, title)}
-                onMouseLeave={() => onLeaveHoverTitle(title)}
+                onMouseEnter={(event) =>
+                  onHoverTitle(getPopperIdRef(title), event)
+                }
+                onMouseLeave={() => onLeaveHoverTitle(getPopperIdRef(title))}
                 sx={getButtonDesign(title)}
               >
                 <TableSortLabel

--- a/my-app/src/pages/work-log/daily/table/header/logic.ts
+++ b/my-app/src/pages/work-log/daily/table/header/logic.ts
@@ -37,10 +37,20 @@ export const DailyTableHeaderLogic = ({ isSelected }: Props) => {
     [isSelected]
   );
 
+  const getPopperIdRef = useCallback(
+    (title: string) => (title == "メインカテゴリ" ? 10000 : 10001),
+    []
+  );
+
   return {
     /** key:テーブルのタイトル名 value:ホバー時のメニュー表示の設定 のオブジェクト */
     headerColumnDisplay,
     /** ボタンのデザイン情報を取得する関数 */
     getButtonDesign,
+    /** ポッパー用のidRefを取得する関数
+     * メインカテゴリ:10000
+     * メインタスク:10001
+     */
+    getPopperIdRef,
   };
 };


### PR DESCRIPTION
# 変更点
- 現在開いているメニュー対象の変数を追加/変更
- メニューを開く/閉じるロジックの条件分岐を更新
- 変数の追加/変更に伴うロジックないの記述を変更

# 詳細
## 各変更内容について
- 開いている対象について
  - 以前：anchorELで保持 -> popperとbuttonで同期ができない！
  - 現在：対象に固有のIDを与えてuseRefで保持 -> 同期ができる！
- 条件分岐について
  - 以前：open対象の有無 -> カテゴリを開いてる時にタスクに重ねてもカテゴリが開き続けたりする
  - 現在：開いている対象のidとリクエストのidが合致するか -> 元のは閉じるし、新しいのを開ける
- Timeoutについて
  - 以前：一つだけ管理 ->複数タブの時間が管理できない
  - 現在：Mapで複数管理 -> 複数タブの時間を管理できる！

## 各変更による修正
- MouseEnter/MouseLeaveイベントハンドラー
  - 識別ようにidを引数に追加 <- 条件分岐に必要なので
  - 関連して、Headerでtitle(string)を渡していたのをid(number)に変更
    - Header内で計算してtitleがカテゴリでは10000,タスクでは10001を渡させる(重複防止目的で)
    - (一応メモではデイリーのidを使用するつもりで、idはいまのところ1から連番にする予定なので問題ないはず)
    - (つまり10000日超えると一瞬だけちょい不都合出るんだけど、さーすがに大丈夫でしょ?)