### PR TITLE
feature:DailyTableフィルターメソッドの実装

### DIFF
--- a/my-app/src/pages/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.tsx
@@ -14,6 +14,7 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import CustomMenuWrapper from "@/component/menu/CustomMenuWrapper/CustomMenuWrapper";
 import CustomMenuCheckBox from "@/component/menu/content/CustomMenuCheckBox/CustomMenuCheckBox";
 import CustomMenuWrapperLogic from "@/component/menu/CustomMenuWrapper/CustomMenuWrapperLogic";
+import CustomMenuTitle from "@/component/menu/content/CustomMenuTitle/CustomMenuTitle";
 
 type Props = {
   /** アイテム */
@@ -23,9 +24,19 @@ type Props = {
  * 日付ページのテーブルコンポーネント
  */
 export default function DailyTable({ itemList }: Props) {
-  const { isAsc, isSelected, handleSetSortTarget, doSortByTitle } =
-    DailyTableLogic();
-  const { handleMouseEnter, handleMouseLeave, ...prev } =
+  const {
+    isAsc,
+    taskFilterList,
+    categoryFilterList,
+    isSelected,
+    handleSetSortTarget,
+    doSortByTitle,
+    getMemoTitleArrayById,
+    toggleCategoryFilterCheckBox,
+    toggleTaskFilterCheckBox,
+    doFilterByFilterList,
+  } = DailyTableLogic({ itemList });
+  const { handleMouseEnter, handleMouseLeave, openTargetIdRef, ...prev } =
     CustomMenuWrapperLogic();
   return (
     <>
@@ -40,6 +51,7 @@ export default function DailyTable({ itemList }: Props) {
           />
           <TableBody>
             {itemList
+              .filter((item) => doFilterByFilterList(item))
               .sort((a, b) => doSortByTitle(a, b))
               .map((item) => (
                 <TableRow
@@ -136,13 +148,28 @@ export default function DailyTable({ itemList }: Props) {
       </TableContainer>
       {/** カスタムメニューの面々   TODO: 条件分岐させる(メモのやつかどっちか) */}
       <CustomMenuWrapper
-        logic={{ handleMouseEnter, handleMouseLeave, ...prev }}
+        logic={{ handleMouseEnter, handleMouseLeave, openTargetIdRef, ...prev }}
       >
-        <CustomMenuCheckBox
-          checkList={{ aaa: false, bbb: false }}
-          onClickSelect={() => {}}
-        />
-        {/* <CustomMenuTitle titleList={["メモタイトル1", "メモタイトル2"]} /> */}
+        {/** カテゴリメニューの場合 */}
+        {openTargetIdRef.current === 10000 && (
+          <CustomMenuCheckBox
+            checkList={categoryFilterList}
+            onClickSelect={toggleCategoryFilterCheckBox}
+          />
+        )}
+        {/** タスクメニューの場合 */}
+        {openTargetIdRef.current === 10001 && (
+          <CustomMenuCheckBox
+            checkList={taskFilterList}
+            onClickSelect={toggleTaskFilterCheckBox}
+          />
+        )}
+        {/** メモの場合 */}
+        {![10000, 10001].includes(openTargetIdRef.current) && (
+          <CustomMenuTitle
+            titleList={getMemoTitleArrayById(openTargetIdRef.current)}
+          />
+        )}
       </CustomMenuWrapper>
     </>
   );

--- a/my-app/src/pages/work-log/daily/table/logic.ts
+++ b/my-app/src/pages/work-log/daily/table/logic.ts
@@ -1,12 +1,47 @@
 import { DateSummary } from "@/type/Date";
 import { useCallback, useState } from "react";
 
+type Props = {
+  /** アイテム */
+  itemList: DateSummary[];
+};
+
 /**
  * 日ごとの一覧ページのテーブルコンポーネントのロジック部分
  */
-export default function DailyTableLogic() {
+export default function DailyTableLogic({ itemList }: Props) {
+  // itemリストに存在するタスク一覧
+  const defaultTaskFilterList = itemList.reduce(
+    (a: Record<string, boolean>, b) => {
+      const taskName = b.taskName;
+      if (!(taskName in a)) {
+        a[taskName] = false;
+      }
+      return a;
+    },
+    {}
+  );
+
+  // itemリストに存在するカテゴリ一覧
+  const defaultCategoryFilterList = itemList.reduce(
+    (a: Record<string, boolean>, b) => {
+      const categoryName = b.categoryName;
+      if (!(categoryName in a)) {
+        a[categoryName] = false;
+      }
+      return a;
+    },
+    {}
+  );
+
   const [selected, setSelected] = useState<string>("日付");
   const [isAsc, setIsAsc] = useState<boolean>(true);
+  const [taskFilterList, setTaskFilterList] = useState<Record<string, boolean>>(
+    defaultTaskFilterList
+  );
+  const [categoryFilterList, setCategoryFilterList] = useState<
+    Record<string, boolean>
+  >(defaultCategoryFilterList);
 
   // 該当するタイトルが選択中か調べる
   const isSelected = useCallback(
@@ -55,14 +90,91 @@ export default function DailyTableLogic() {
     [isAsc, selected]
   );
 
+  // idからメモのタイトル一覧を取得する関数
+  const getMemoTitleArrayById = useCallback(
+    (id: number) => {
+      const target = itemList.find((item) => item.id === id);
+      const array: string[] = [];
+      if (target) {
+        target.memo.forEach((item) => array.push(item.title));
+      }
+      return array;
+    },
+    [itemList]
+  );
+
+  // カテゴリーフィルターリストのチェックのOnOffを切り替える関数
+  const toggleCategoryFilterCheckBox = useCallback(
+    (name: string) => {
+      const newValue = !categoryFilterList[name];
+      console.log(newValue);
+      setCategoryFilterList((prev) => ({ ...prev, [name]: newValue }));
+    },
+    [categoryFilterList]
+  );
+
+  // タスクフィルターリストのチェックのOnOffを切り替える関数
+  const toggleTaskFilterCheckBox = useCallback(
+    (name: string) => {
+      const newValue = !taskFilterList[name];
+      setTaskFilterList((prev) => ({ ...prev, [name]: newValue }));
+    },
+    [, taskFilterList]
+  );
+
+  // 選択されている内容に応じてフィルターする関数
+  const doFilterByFilterList = useCallback(
+    (item: DateSummary): boolean => {
+      // フィルターがセットされていない場合、trueを返してフィルターしない
+      const isNoCategoryFilter = Object.values(categoryFilterList).every(
+        (value) => value === false
+      );
+      const isNoTaskFilter = Object.values(taskFilterList).every(
+        (value) => value === false
+      );
+      if (isNoCategoryFilter && isNoTaskFilter) {
+        return true;
+      }
+      // カテゴリとタスクについてフィルターが存在する場合にカット対象か検証して、対象であれば早期にfalseでreturnする
+      // カテゴリーについて
+      if (!isNoCategoryFilter) {
+        const isCutByCategory = !categoryFilterList[item.categoryName];
+        if (isCutByCategory) {
+          return false;
+        }
+      }
+      // タスクについて
+      if (!isNoTaskFilter) {
+        const isCutByTask = !taskFilterList[item.taskName];
+        if (isCutByTask) {
+          return false;
+        }
+      }
+      return true;
+    },
+    [categoryFilterList, taskFilterList]
+  );
+
   return {
     /** 現在昇順かどうか */
     isAsc,
+    /** アイテムのタスク名とチェック状態のRecordオブジェクト */
+    taskFilterList,
+    /** アイテムのカテゴリ名とチェック状態のRecordオブジェクト */
+    categoryFilterList,
     /** 選択中かどうか調べる関数 */
     isSelected,
     /** ソート対象を関数 */
     handleSetSortTarget,
     /** ソートする関数 */
     doSortByTitle,
+    /** 該当するidのデータのメモのタイトルの配列を取得する関数 */
+    getMemoTitleArrayById,
+    /** カテゴリのフィルターリストのチェックボックスを切り替える関数 */
+    toggleCategoryFilterCheckBox,
+    /** タスクのフィルターリストのチェックボックスを切り替える関数 */
+    toggleTaskFilterCheckBox,
+    /** フィルターリストに応じてフィルターする関数 */
+    doFilterByFilterList,
   };
 }


### PR DESCRIPTION
# 変更点
- タスク・カテゴリでフィルター可能に
- フィルター対象のチェックボックスのUIとクリックの動作同期

# 詳細
- フィルター対象のリストをuseStateで管理
  - task,categoryで別々に管理
  - 型はMenuと合わせてRecord<string,boolean>で管理
- クリック時の関数を定義
  - task,catogryでそれぞれ定義 Recordのコピーを作成してsetさせる
- フィルターの関数を定義
  - 展開前のArray.filter()で使用
  - フィルター対象がない場合はフィルターしない
  - 対象がある場合は対象のある項目(task,category)でだけフィルターを行う

# なんかまちがえて入ってたやつ的な
メモ関連
どっかで入れる予定だったのにここに入っちゃったっぽい
メモのタイトル一覧を取得　->表示ってな感じ
多分一個前？の漏れ