### PR TITLE
feature:DailyTableに渡し忘れてたナビゲーションについてのイベントハンドラーを追加

### DIFF
--- a/my-app/src/pages/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.tsx
@@ -19,11 +19,13 @@ import CustomMenuTitle from "@/component/menu/content/CustomMenuTitle/CustomMenu
 type Props = {
   /** アイテム */
   itemList: DateSummary[];
+  /** rowをクリックした際のページナビゲーションのハンドラー */
+  onClickRow: (id: number) => void;
 };
 /**
  * 日付ページのテーブルコンポーネント
  */
-export default function DailyTable({ itemList }: Props) {
+export default function DailyTable({ itemList, onClickRow }: Props) {
   const {
     isAsc,
     taskFilterList,
@@ -57,7 +59,7 @@ export default function DailyTable({ itemList }: Props) {
                 <TableRow
                   key={item.id}
                   hover
-                  onClick={() => {}}
+                  onClick={() => onClickRow(item.id)}
                   sx={{
                     cursor: "pointer",
                   }}


### PR DESCRIPTION
# 変更点
- 行のonClickイベントを引数に追加

# 詳細
- 詳細ページへのナビゲーション用の関数を引数に追加
  - わたすの忘れてたので！
  - 詳しい実装についてはページの一番上の方で他のナビゲーションと一緒にまとめて行う予定！