### PR TITLE
ui:DailyPageダイアログのuiを作成

### DIFF
--- a/my-app/src/pages/work-log/daily/dialog/DateDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/dialog/DateDialog.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import DateDialog from "./DateDialog";
+
+const meta = {
+  component: DateDialog,
+  args: {
+    categoryList: [
+      {
+        id: 0,
+        name: "カテゴリ1",
+        taskList: [
+          { id: 0, name: "タスク1", percent: "80%" },
+          { id: 1, name: "タスク2", percent: "20%" },
+        ],
+        percent: "60%",
+      },
+      {
+        id: 1,
+        name: "カテゴリ2",
+        taskList: [
+          { id: 0, name: "タスク3", percent: "80%" },
+          { id: 1, name: "タスク4", percent: "20%" },
+        ],
+        percent: "30%",
+      },
+      {
+        id: 2,
+        name: "カテゴリ3",
+        taskList: [
+          { id: 0, name: "タスク5", percent: "80%" },
+          { id: 1, name: "タスク6", percent: "20%" },
+        ],
+        percent: "10%",
+      },
+    ],
+    memoList: [
+      { id: 0, title: "メモ1" },
+      { id: 1, title: "メモ2" },
+      { id: 2, title: "メモ3" },
+      { id: 3, title: "メモ4" },
+      { id: 4, title: "メモ5" },
+      { id: 5, title: "メモ6" },
+      { id: 6, title: "メモ7" },
+      { id: 7, title: "メモ8" },
+      { id: 8, title: "メモ9" },
+    ],
+  },
+} satisfies Meta<typeof DateDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/pages/work-log/daily/dialog/DateDialog.tsx
+++ b/my-app/src/pages/work-log/daily/dialog/DateDialog.tsx
@@ -1,0 +1,135 @@
+import {
+  Button,
+  Dialog,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
+
+type Props = {
+  /** タスクの概要の配列 */
+  categoryList: {
+    id: number;
+    name: string;
+    taskList: { id: number; name: string; percent: string }[];
+    percent: string;
+  }[];
+  /** メモのタイトル一覧 */
+  memoList: { id: number; title: string }[];
+};
+/**
+ * 日付ページの日付を指定して移動するダイアログのコンポーネント
+ */
+export default function DateDialog({ categoryList, memoList }: Props) {
+  return (
+    <Dialog open={true}>
+      <Stack width="500px" height="300px" p={3} spacing={7}>
+        {/** 上半分 */}
+        <Stack height="25%">
+          <FormControl>
+            {/** ラジオボタン */}
+            <RadioGroup
+              sx={{ transform: "scale(0.7)", transformOrigin: "left top" }}
+              row
+            >
+              <FormControlLabel value="昨日" control={<Radio />} label="昨日" />
+              <FormControlLabel
+                value="一昨日"
+                control={<Radio />}
+                label="一昨日"
+              />
+              <FormControlLabel
+                value="指定する"
+                control={<Radio />}
+                label="指定する"
+              />
+            </RadioGroup>
+          </FormControl>
+          {/** 日付フォーム */}
+          <Stack direction="row" spacing={2}>
+            {["年", "月", "日"].map((v) => (
+              <FormControl key={v} variant="standard" sx={{ minWidth: 90 }}>
+                <InputLabel>{v}</InputLabel>
+                <Select value="仮データ" label={v}>
+                  {v === "年"}
+                  <MenuItem value="仮データ">{v}</MenuItem>
+                </Select>
+              </FormControl>
+            ))}
+          </Stack>
+        </Stack>
+        {/** 下半分 */}
+        <Stack height="55%" direction="row">
+          {/** 左下 */}
+          <Stack width="50%" overflow={"auto"} spacing={1}>
+            {/** カテゴリ+タスクごとの塊 */}
+            {categoryList.map((item) => (
+              <Stack key={item.id} pb={0.5}>
+                {/* カテゴリタイトル */}
+                <Stack
+                  direction={"row"}
+                  justifyContent={"space-between"}
+                  pr={5}
+                >
+                  <Typography
+                    variant="subtitle2"
+                    textOverflow={"ellipsis"}
+                    whiteSpace={"nowrap"}
+                    maxWidth={"70%"}
+                    overflow={"hidden"}
+                  >
+                    {item.name}
+                  </Typography>
+                  <Typography variant="subtitle2">{item.percent}</Typography>
+                </Stack>
+                {/* タスクタイトル */}
+                {item.taskList.map((task) => (
+                  <Stack
+                    key={task.id}
+                    direction={"row"}
+                    justifyContent={"space-between"}
+                    pr={5}
+                  >
+                    <Typography
+                      pl={5}
+                      variant="caption"
+                      textOverflow={"ellipsis"}
+                      whiteSpace={"nowrap"}
+                      maxWidth={"70%"}
+                      overflow={"hidden"}
+                    >
+                      {task.name}
+                    </Typography>
+                    <Typography variant="caption">{task.percent}</Typography>
+                  </Stack>
+                ))}
+              </Stack>
+            ))}
+          </Stack>
+          {/** 右下 */}
+          <Stack width="50%" justifyContent={"space-between"}>
+            {/** メモのところ */}
+            <Stack height="70%" overflow="auto" pl={2}>
+              <Typography variant="subtitle1">メモ</Typography>
+              {memoList.map((item) => (
+                <Typography key={item.id} pl={4} variant="caption">
+                  {item.title}
+                </Typography>
+              ))}
+            </Stack>
+            <Stack width="50%" alignSelf={"center"}>
+              <Button startIcon={<ArrowCircleRightIcon />}>移動</Button>
+            </Stack>
+          </Stack>
+        </Stack>
+      </Stack>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# 変更点
- ダイアログのデザインを作成

# 詳細
- 基本のデザイン(日付が指定されていて、その情報がロードされた状態)を作成

## 各種デザイン
- 上部
  - ラジオボタン
    - 日付を指定するか、あるいはそのまま昨日/一昨日の日を選択可能
  - セレクト
    - 年・月・日それぞれについて別個で存在
- 下部
  - サマリー表示
    - 左部にカテゴリーごとにタスクを表示
    - 各カテゴリー・カテゴリーを占めるタスクの割合をそれぞれ表示
    - 右部にメモの一覧を表示
  - 右下に移動ボタンを配置

# 注意点
- ロジックは未実装なため、今後の実装でstorybook上でラジオボタンの操作は不能になる予定です
- つまり、状態管理の管轄は後々上で管理させる予定なので、いまんところ色々操作ができるのはuiの実装段階であるためであります！