### PR TITLE
ui:DailyPageがっちゃんこしてuiの位置だけ調整

### DIFF
--- a/my-app/src/pages/work-log/daily/page.stories.tsx
+++ b/my-app/src/pages/work-log/daily/page.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Page from './page';
+
+const meta = {
+  component: Page,
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {}
+};

--- a/my-app/src/pages/work-log/daily/page.tsx
+++ b/my-app/src/pages/work-log/daily/page.tsx
@@ -1,0 +1,50 @@
+import { Stack } from "@mui/material";
+import DailyHeader from "./header/DailyHeader";
+import DailyTable from "./table/DailyTable";
+import DateDialog from "./dialog/DateDialog";
+import { DUMMY_DAILY_SUMMARY_DATA } from "@/dummy/daily-page";
+
+/**
+ * DailyPage
+ */
+export default function DailyPage() {
+  return (
+    <>
+      <Stack spacing={2}>
+        <DailyHeader
+          displayYear=""
+          displayMonth=""
+          isLoading={false}
+          handlePrev={() => {}}
+          handleNext={() => {}}
+          handleYearChange={() => {}}
+          handleMonthChange={() => {}}
+          onClickEditToday={() => {}}
+          onClickEditSelectDate={() => {}}
+        />
+        <DailyTable itemList={DUMMY_DAILY_SUMMARY_DATA} onClickRow={() => {}} />
+      </Stack>
+      <DateDialog
+        categoryList={[]}
+        memoList={[]}
+        logic={{
+          open: false,
+          radioSelect: "一昨日",
+          selectYear: 2025,
+          selectMonth: 4,
+          selectDay: 1,
+          selectableYearArray: [],
+          selectableMonthArray: [],
+          selectableDayArray: [],
+          onClose: () => {},
+          onOpen: () => {},
+          onChangeRadioSelect: () => {},
+          onSelectYear: () => {},
+          onSelectMonth: () => {},
+          onSelectDay: () => {},
+        }}
+        isLoading={false}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
# 変更点
- DailyPageのパーツをがっちゃんこしてページのUIさくせい

# 詳細
- 引数に空値与えてDailyPageの各コンポーネントを配置
- Stackで囲んで配置位置を調整しつつ