### PR TITLE
feature:ロード状態とからの時の状態を作成

### DIFF
--- a/my-app/src/pages/work-log/daily/page.tsx
+++ b/my-app/src/pages/work-log/daily/page.tsx
@@ -40,6 +40,7 @@ export default function DailyPage() {
         <DailyTable
           itemList={itemList}
           onClickRow={handleNavigateSelectedDay}
+          isLoading={isLoadingItemList}
         />
       </Stack>
       <DateDialog

--- a/my-app/src/pages/work-log/daily/table/DailyTable.stories.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.stories.tsx
@@ -5,13 +5,17 @@ import { DUMMY_DAILY_SUMMARY_DATA } from "@/dummy/daily-page";
 
 const meta = {
   component: DailyTable,
-  args: { itemList: DUMMY_DAILY_SUMMARY_DATA },
+  args: {
+    itemList: DUMMY_DAILY_SUMMARY_DATA,
+    isLoading: false,
+    onClickRow: () => {},
+  },
 } satisfies Meta<typeof DailyTable>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {},
-};
+export const Default: Story = {};
+export const Loading: Story = { args: { isLoading: true } };
+export const Empty: Story = { args: { itemList: [] } };

--- a/my-app/src/pages/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/pages/work-log/daily/table/DailyTable.tsx
@@ -1,4 +1,5 @@
 import {
+  CircularProgress,
   Table,
   TableBody,
   TableCell,
@@ -19,13 +20,15 @@ import CustomMenuTitle from "@/component/menu/content/CustomMenuTitle/CustomMenu
 type Props = {
   /** アイテム */
   itemList: DateSummary[];
+  /** ロード状態か */
+  isLoading: boolean;
   /** rowをクリックした際のページナビゲーションのハンドラー */
   onClickRow: (id: number) => void;
 };
 /**
  * 日付ページのテーブルコンポーネント
  */
-export default function DailyTable({ itemList, onClickRow }: Props) {
+export default function DailyTable({ itemList, isLoading, onClickRow }: Props) {
   const {
     isAsc,
     taskFilterList,
@@ -52,99 +55,145 @@ export default function DailyTable({ itemList, onClickRow }: Props) {
             onLeaveHoverTitle={handleMouseLeave}
           />
           <TableBody>
-            {itemList
-              .filter((item) => doFilterByFilterList(item))
-              .sort((a, b) => doSortByTitle(a, b))
-              .map((item) => (
-                <TableRow
-                  key={item.id}
-                  hover
-                  onClick={() => onClickRow(item.id)}
-                  sx={{
-                    cursor: "pointer",
-                  }}
-                >
-                  {/** 日付 */}
+            {isLoading && (
+              <>
+                <TableRow>
                   <TableCell
-                    sx={{
-                      maxWidth: "150px", // 幅
-                      width: "150px", // 幅
-                      overflow: "hidden",
-                      whiteSpace: "nowrap",
-                      textOverflow: "ellipsis",
-                    }}
+                    colSpan={5}
+                    sx={{ height: "200px" }}
+                    align="center"
                   >
-                    <Typography>{format(item.date, "yyyy-MM-dd")}</Typography>
+                    <CircularProgress />
                   </TableCell>
-                  {/** メインカテゴリ */}
+                </TableRow>
+                {/* カラムの幅を維持するための透明なダミー行 */}
+                <TableRow style={{ border: "none", height: 0 }}>
+                  {[...Array(5)].map((_, index) => (
+                    <TableCell
+                      key={index}
+                      sx={{ width: "20%", border: "none" }}
+                    />
+                  ))}
+                </TableRow>
+              </>
+            )}
+            {!isLoading && itemList.length === 0 && (
+              <>
+                <TableRow>
                   <TableCell
-                    sx={{
-                      maxWidth: "150px", // 幅
-                      width: "150px", // 幅
-                      overflow: "hidden",
-                      whiteSpace: "nowrap",
-                      textOverflow: "ellipsis",
-                    }}
+                    colSpan={5}
+                    align="center"
+                    sx={{ height: "200px" }}
                   >
-                    {item.categoryName}
+                    データがありません
                   </TableCell>
-                  {/** メインタスク */}
-                  <TableCell
+                </TableRow>
+                {/* カラムの幅を維持するための透明なダミー行 */}
+                <TableRow style={{ border: "none", height: 0 }}>
+                  {[...Array(5)].map((_, index) => (
+                    <TableCell
+                      key={index}
+                      sx={{ width: "20%", border: "none" }}
+                    />
+                  ))}
+                </TableRow>
+              </>
+            )}
+            {!isLoading &&
+              itemList.length > 0 &&
+              itemList
+                .filter((item) => doFilterByFilterList(item))
+                .sort((a, b) => doSortByTitle(a, b))
+                .map((item) => (
+                  <TableRow
+                    key={item.id}
+                    hover
+                    onClick={() => onClickRow(item.id)}
                     sx={{
-                      maxWidth: "150px", // 幅
-                      width: "150px", // 幅
-                      overflow: "hidden",
-                      whiteSpace: "nowrap",
-                      textOverflow: "ellipsis",
+                      cursor: "pointer",
                     }}
                   >
-                    {item.taskName}
-                  </TableCell>
-                  {/** メモ(0番目のめもを表示)  TODO:展開できるようにする*/}
-                  <TableCell
-                    sx={{
-                      maxWidth: "150px", // 幅
-                      width: "150px", // 幅
-                      gap: 2,
-                      borderRadius: "4px",
-                      transition: "background 0.5s",
-                      "&:hover": {
-                        backgroundColor: "rgba(31, 158, 255, 0.37)",
-                      },
-                    }}
-                    onMouseEnter={(e) => handleMouseEnter(item.id, e)}
-                    onMouseLeave={() => handleMouseLeave(item.id)}
-                  >
-                    <Typography
+                    {/** 日付 */}
+                    <TableCell
                       sx={{
+                        maxWidth: "20%", // 幅
+                        width: "20%", // 幅
                         overflow: "hidden",
                         whiteSpace: "nowrap",
                         textOverflow: "ellipsis",
                       }}
                     >
-                      {item.memo[0].title}
-                    </Typography>
-                    <KeyboardArrowDownIcon
+                      <Typography>{format(item.date, "yyyy-MM-dd")}</Typography>
+                    </TableCell>
+                    {/** メインカテゴリ */}
+                    <TableCell
                       sx={{
-                        opacity: 0.6,
-                        fontSize: 20,
+                        maxWidth: "20%", // 幅
+                        width: "20%", // 幅
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
+                        textOverflow: "ellipsis",
                       }}
-                    />
-                  </TableCell>
-                  {/** 稼働合計 */}
-                  <TableCell
-                    sx={{
-                      maxWidth: "150px", // 幅
-                      width: "150px", // 幅
-                      overflow: "hidden",
-                      whiteSpace: "nowrap",
-                      textOverflow: "ellipsis",
-                    }}
-                  >
-                    <Typography>{item.dailyHours}</Typography>
-                  </TableCell>
-                </TableRow>
-              ))}
+                    >
+                      {item.categoryName}
+                    </TableCell>
+                    {/** メインタスク */}
+                    <TableCell
+                      sx={{
+                        maxWidth: "20%", // 幅
+                        width: "20%", // 幅
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {item.taskName}
+                    </TableCell>
+                    {/** メモ(0番目のめもを表示)  TODO:展開できるようにする*/}
+                    <TableCell
+                      sx={{
+                        maxWidth: "20%", // 幅
+                        width: "20%", // 幅
+                        gap: 2,
+                        borderRadius: "4px",
+                        transition: "background 0.5s",
+                        "&:hover": {
+                          backgroundColor: "rgba(31, 158, 255, 0.37)",
+                        },
+                      }}
+                      onMouseEnter={(e) => handleMouseEnter(item.id, e)}
+                      onMouseLeave={() => handleMouseLeave(item.id)}
+                    >
+                      <Typography
+                        sx={{
+                          overflow: "hidden",
+                          whiteSpace: "nowrap",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {item.memo[0].title}
+                      </Typography>
+                      <KeyboardArrowDownIcon
+                        sx={{
+                          opacity: 0.6,
+                          fontSize: 20,
+                        }}
+                      />
+                    </TableCell>
+                    {/** 稼働合計 */}
+                    <TableCell
+                      sx={{
+                        maxWidth: "20%", // 幅
+                        width: "20%", // 幅
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      <Typography>{item.dailyHours}</Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
           </TableBody>
         </Table>
       </TableContainer>


### PR DESCRIPTION
# 変更点
- ローディングの引数追加
  - ロード状態を作成
- データが空のときを作成

# 詳細
## デザイン
- 共通
  - データがない(フェッチ前/フェッチ後同様に)際にダミーの行でヘッダーの幅が固定化されるように調整
  - bodyの高さがロード中と空の時で同様になるように調整(ロード完了時にデータがない場合はテーブルの高さも崩れなくなる！)
- ロード
  - インジケータをbody中央に配置
- からのとき
  - データがない旨のtextをbody中央に配置
## ロジック
- ロード状態
  - データフェッチ時に親から状態を取得
  - ロード時はデータの参照を行わない
- から状態
  - データフェッチ後にからデータだった場合
  - データがない旨を表示