### PR TITLE
feature:DailyPageダイアログ ナビゲーション関数の実装

### DIFF
--- a/my-app/src/pages/work-log/daily/dialog/DateDialog.tsx
+++ b/my-app/src/pages/work-log/daily/dialog/DateDialog.tsx
@@ -16,28 +16,34 @@ import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
 import DataDialogLogic from "./DateDialogLogic";
 
 type Props = {
-  /** タスクの概要の配列 */
-  categoryList: {
+  /** 特定の日付詳細データのダイアログ用データ */
+  dateDetails: {
     id: number;
-    name: string;
-    taskList: { id: number; name: string; percent: string }[];
-    percent: string;
-  }[];
-  /** メモのタイトル一覧 */
-  memoList: { id: number; title: string }[];
+    /** タスクの概要の配列 */
+    categoryList: {
+      id: number;
+      name: string;
+      taskList: { id: number; name: string; percent: string }[];
+      percent: string;
+    }[];
+    /** メモのタイトル一覧 */
+    memoList: { id: number; title: string }[];
+  };
   /** このダイアログの固有ロジック群 */
   logic: ReturnType<typeof DataDialogLogic>;
   /** ロード状態か */
   isLoading: boolean;
+  /** ページを移動する関数 */
+  navigatePage: (id: number) => void;
 };
 /**
  * 日付ページの日付を指定して移動するダイアログのコンポーネント
  */
 export default function DateDialog({
-  categoryList,
-  memoList,
+  dateDetails,
   logic,
   isLoading,
+  navigatePage,
 }: Props) {
   const {
     open,
@@ -149,7 +155,7 @@ export default function DateDialog({
             )}
             {/** カテゴリ+タスクごとの塊 */}
             {!isLoading &&
-              categoryList.map((item) => (
+              dateDetails.categoryList.map((item) => (
                 <Stack key={item.id} pb={0.5}>
                   {/* カテゴリタイトル */}
                   <Stack
@@ -203,7 +209,7 @@ export default function DateDialog({
               )}
               {!isLoading && <Typography variant="subtitle1">メモ</Typography>}
               {!isLoading &&
-                memoList.map((item) => (
+                dateDetails.memoList.map((item) => (
                   <Typography key={item.id} pl={4} variant="caption">
                     {item.title}
                   </Typography>
@@ -213,7 +219,7 @@ export default function DateDialog({
               <Button
                 onClick={() => {
                   onClose();
-                  // TODO:ナビゲーション関連の関数もいる！
+                  navigatePage(dateDetails.id);
                 }}
                 startIcon={<ArrowCircleRightIcon />}
               >

--- a/my-app/src/pages/work-log/daily/page.tsx
+++ b/my-app/src/pages/work-log/daily/page.tsx
@@ -43,10 +43,10 @@ export default function DailyPage() {
         />
       </Stack>
       <DateDialog
-        categoryList={detailData.categoryList}
-        memoList={detailData.memoList}
+        dateDetails={detailData}
         logic={{ onOpen, ...prevDialogLogic }}
         isLoading={isLoadingDetail}
+        navigatePage={handleNavigateSelectedDay}
       />
     </>
   );


### PR DESCRIPTION
# 変更点
- 移動ボタン押した際にナビゲーションできるように変更

# 詳細
- 親から引数でナビゲーション関数を受け取るように変更
  - 機能自体は未実装
  - idから移動するように変更
- 受け取る構造体の形式を変更
  - そのデータのidを受け取れるように変更
    - idで詳細ページ飛びたいので
  - ついでに、categoryListとmemoListを一つの構造体で渡すように変更
    - idつけるんだったら関連付けさせたいし