### PR TITLE
feature:DailyPageダイアログ　データフェッチの仕組み実装

### DIFF
--- a/my-app/src/pages/work-log/daily/dialog/params.ts
+++ b/my-app/src/pages/work-log/daily/dialog/params.ts
@@ -1,5 +1,8 @@
 import { getDate, getDaysInMonth, getMonth, getYear, subDays } from "date-fns";
 
+// 今日
+const today = new Date();
+
 /** 今年 */
 export const currentYear = getYear(new Date());
 
@@ -10,6 +13,18 @@ export const currentMonth = getMonth(new Date()) + 1;
 export const currentDate = getDate(new Date()); // 例: 31
 /** 昨日 */
 export const yesterday = getDate(subDays(new Date(), 1)); // 例: 31
+
+/** 昨日 */
+const yesterdayFullDate = subDays(today, 1);
+export const yesterdayYear = getYear(yesterdayFullDate);
+export const yesterdayMonth = getMonth(yesterdayFullDate) + 1; // 0-based month, so +1
+export const yesterdayDate = getDate(yesterdayFullDate);
+
+/** 一昨日 */
+const dayBeforeYesterdayFullDate = subDays(today, 2);
+export const dayBeforeYesterdayYear = getYear(dayBeforeYesterdayFullDate);
+export const dayBeforeYesterdayMonth = getMonth(dayBeforeYesterdayFullDate) + 1; // 0-based month, so +1
+export const dayBeforeYesterdayDate = getDate(dayBeforeYesterdayFullDate);
 
 /** 年の選択肢の配列(2015年~今の年)を取得する関数 */
 export const getYearSelectArray = () => {

--- a/my-app/src/pages/work-log/daily/fetchLogic.ts
+++ b/my-app/src/pages/work-log/daily/fetchLogic.ts
@@ -3,11 +3,16 @@ import {
   DUMMY_DAILY_SUMMARY_DATA,
   DUMMY_MEMO_LIST,
 } from "@/dummy/daily-page";
+import { useCallback, useRef } from "react";
+import { yesterdayDate, yesterdayMonth, yesterdayYear } from "./dialog/params";
 
 /**
  * DailyPageのフェッチ関連のロジック
  */
 export default function DailyPageFetchLogic() {
+  const detailDataParams = useRef<{ year: number; month: number; day: number }>(
+    { year: yesterdayYear, month: yesterdayMonth, day: yesterdayDate }
+  );
   // TODO:SWRで取得
   const itemList = DUMMY_DAILY_SUMMARY_DATA;
   const isLoadingItemList = false;
@@ -19,6 +24,24 @@ export default function DailyPageFetchLogic() {
   };
   const isLoadingDetail = false;
 
+  // TODO:クエリパラメータを構成して、SWRでフェッチさせる
+  const onFetchDetails = useCallback(
+    (params: { year?: number; month?: number; day?: number }) => {
+      const query = new URLSearchParams();
+      // クエリパラメータのref値を変更
+      if (params.year) detailDataParams.current.year = params.year;
+      if (params.month) detailDataParams.current.month = params.month;
+      if (params.day) detailDataParams.current.day = params.day;
+      // クエリを変更
+      query.set("year", String(detailDataParams.current.year));
+      query.set("month", String(detailDataParams.current.month));
+      query.set("day", String(detailDataParams.current.day));
+      console.log("新しいクエリ", query.toString());
+      // TODO:SWRでここでフェッチ
+    },
+    []
+  );
+
   return {
     /** アイテム全体のリスト */
     itemList,
@@ -28,5 +51,7 @@ export default function DailyPageFetchLogic() {
     detailData,
     /** アイテム詳細(ダイアログのやつ)のロード状態 */
     isLoadingDetail,
+    /** 詳細データ(ダイアログのやつ)のフェッチ関数 */
+    onFetchDetails,
   };
 }

--- a/my-app/src/pages/work-log/daily/page.tsx
+++ b/my-app/src/pages/work-log/daily/page.tsx
@@ -10,9 +10,13 @@ import DailyPageNavigationLogic from "./navigationLogic";
  * DailyPage
  */
 export default function DailyPage() {
-  const { onOpen, ...prevDialogLogic } = DataDialogLogic();
-  const { itemList, isLoadingItemList, detailData, isLoadingDetail } =
-    DailyPageFetchLogic();
+  const {
+    itemList,
+    isLoadingItemList,
+    detailData,
+    isLoadingDetail,
+    onFetchDetails,
+  } = DailyPageFetchLogic();
   const {
     displayYear,
     displayMonth,
@@ -23,6 +27,9 @@ export default function DailyPage() {
     handleNavigateToday,
     handleNavigateSelectedDay,
   } = DailyPageNavigationLogic();
+  const { onOpen, ...prevDialogLogic } = DataDialogLogic({
+    onFetchData: onFetchDetails,
+  });
   return (
     <>
       <Stack spacing={2}>


### PR DESCRIPTION
# 変更点
- ダイアログ操作時に詳細データを再度フェッチできるよう変更

# 詳細
- ロジックの引数にフェッチ関数を追加
 
## ダイアログlogic側
- 引数追加
  - フェッチ関数
- ラジオボタン操作時
  - 昨日/一昨日/指定ボタンを押した際にフェッチ関数を呼び出すように変更
- セレクト
  - いずれかの値を変更した際に1秒後にフェッチ関数を呼び出すように変更
    - 1秒以内に再度操作した場合はキャンセルして、再度一秒後に呼び出す

## ページ側
- フェッチに使用したパラメータをuseRefで管理
  - セレクトで特定のパラメータのみ変更した場合に使いまわせるように
- フェッチ関数を定義
  - useRefのパラメータに渡されたパラメータを保持させて、それをまとめてクエリとしてフェッチさせる　予定
  - SWRは未実装(パラメータはまとめてconsoleで表示できるようになってる)