### PR TITLE
fix:セレクトの遅延時間中に他のセレクトを変更した際に、遅延時間中に行ったセレクトの状態の同期がズレる問題

### DIFF
--- a/my-app/src/pages/work-log/daily/dialog/DateDialogLogic.ts
+++ b/my-app/src/pages/work-log/daily/dialog/DateDialogLogic.ts
@@ -1,4 +1,4 @@
-import { debounce, SelectChangeEvent } from "@mui/material";
+import { SelectChangeEvent } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import {
   dayBeforeYesterdayDate,
@@ -39,13 +39,6 @@ export default function DataDialogLogic({ onFetchData }: Props) {
   const [selectYear, setSelectYear] = useState<number>(yesterdayYear);
   const [selectMonth, setSelectMonth] = useState<number>(yesterdayMonth);
   const [selectDay, setSelectDay] = useState<number>(yesterdayDate);
-
-  const debouncedFetch = debounce(
-    (params: { year?: number; month?: number; day?: number }) => {
-      onFetchData(params);
-    },
-    1000
-  );
 
   const selectableYearArray = useMemo(() => getYearSelectArray(), []);
   const selectableMonthArray = useMemo(
@@ -106,27 +99,27 @@ export default function DataDialogLogic({ onFetchData }: Props) {
     (e: SelectChangeEvent) => {
       const target = e.target.value;
       setSelectYear(Number(target));
-      debouncedFetch({ year: Number(target) });
+      onFetchData({ year: Number(target) });
     },
-    [debouncedFetch]
+    [onFetchData]
   );
 
   const onSelectMonth = useCallback(
     (e: SelectChangeEvent) => {
       const target = e.target.value;
       setSelectMonth(Number(target));
-      debouncedFetch({ month: Number(target) });
+      onFetchData({ month: Number(target) });
     },
-    [debouncedFetch]
+    [onFetchData]
   );
 
   const onSelectDay = useCallback(
     (e: SelectChangeEvent) => {
       const target = e.target.value;
       setSelectDay(Number(target));
-      debouncedFetch({ day: Number(target) });
+      onFetchData({ day: Number(target) });
     },
-    [debouncedFetch]
+    [onFetchData]
   );
 
   return {


### PR DESCRIPTION
# 修正点
- 表題通り
->セレクトの遅延を削除して対処

# 詳細
## 前提条件

初期値 
selectYear:defaultYear 
selectMonth:defaultMonth 
selectDay:defaultDay (この値は変更されませんが、セレクトが保持する値の一つであるため一応デフォ値与えてます)

変更後の値
selectYear:newYear 
selectMonth:newMonth

## 実際の動作
セレクト[年]をnewYearに変更
-> setSelectYearでnewYearがセットされる
-> 1秒以内にセレクト[月]をnewMonthに変更
-> setSelectMonthでnewMonthがセットされる
-> 1秒待機
-> onFetchでnewMonthの値が与えられる
 
## 結果
ダイアログ側:
selectYear:newYear , 
selectMonth:newMonth

onFetch側:
selectYear:defaultYear,         <- ダイアログと違う値になってる！
selectMonth:newMonth
このように同期がずれてしまう

## 対処
遅延切って対処！
遅延がなくてもセレクトならそんな操作できなさそうなので、問題ないと思う！

問題あれば代わりにセレクトでyear/month/day全て渡す形に変更する予定！！！！