### PR TITLE
refactor:別のとこで使いたいので、ヘッダーのソートラベルを分離

### DIFF
--- a/my-app/src/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel.stories.tsx
+++ b/my-app/src/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CustomHeaderSortCheckLabel from './CustomHeaderSortCheckLabel';
+
+const meta = {
+  component: CustomHeaderSortCheckLabel,
+} satisfies Meta<typeof CustomHeaderSortCheckLabel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "title",
+    isSelected: true,
+    isAsc: true,
+    refId: 0,
+    onClickTitle: () => {},
+    onHoverTitle: () => {},
+    onLeaveTitle: () => {}
+  }
+};

--- a/my-app/src/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel.tsx
+++ b/my-app/src/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel.tsx
@@ -1,0 +1,49 @@
+import { ButtonBase, TableSortLabel } from "@mui/material";
+import HeaderDesign from "../useHeaderLabelDesign";
+
+type Props = {
+  /** タイトル */
+  title: string;
+  /** 選択状態かどうか */
+  isSelected: boolean;
+  /** 昇順かどうか */
+  isAsc: boolean;
+  /** 対象についての参照id */
+  refId: number;
+  /** タイトルをクリックした際のハンドラー */
+  onClickTitle: (title: string) => void;
+  /** タイトルをホバーした際のハンドラー */
+  onHoverTitle: (refId: number, e: React.MouseEvent<HTMLElement>) => void;
+  /** タイトルからリーブした際のハンドラー */
+  onLeaveTitle: (refId: number) => void;
+};
+
+/**
+ * ソート可能なホバー時にチェックボックスを表示させるヘッダーラベル
+ */
+export default function CustomHeaderSortCheckLabel({
+  title,
+  isSelected,
+  isAsc,
+  refId,
+  onClickTitle,
+  onHoverTitle,
+  onLeaveTitle,
+}: Props) {
+  const { customDesign } = HeaderDesign({ isSelected });
+  return (
+    <ButtonBase
+      onClick={() => onClickTitle(title)}
+      onMouseEnter={(e) => onHoverTitle(refId, e)}
+      onMouseLeave={() => onLeaveTitle(refId)}
+      sx={customDesign}
+    >
+      <TableSortLabel
+        active={isSelected}
+        direction={isSelected && !isAsc ? "desc" : "asc"}
+      >
+        {title}
+      </TableSortLabel>
+    </ButtonBase>
+  );
+}

--- a/my-app/src/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel.stories.tsx
+++ b/my-app/src/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CustomHeaderSortLabel from './CustomHeaderSortLabel';
+
+const meta = {
+  component: CustomHeaderSortLabel,
+} satisfies Meta<typeof CustomHeaderSortLabel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "title",
+    isSelected: true,
+    isAsc: true,
+    onClickTitle: () => {}
+  }
+};

--- a/my-app/src/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel.tsx
+++ b/my-app/src/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel.tsx
@@ -1,0 +1,34 @@
+import { ButtonBase, TableSortLabel } from "@mui/material";
+import HeaderDesign from "../useHeaderLabelDesign";
+
+type Props = {
+  /** タイトル */
+  title: string;
+  /** 選択状態かどうか */
+  isSelected: boolean;
+  /** 昇順かどうか */
+  isAsc: boolean;
+  /** タイトルをクリックした際のハンドラー */
+  onClickTitle: (title: string) => void;
+};
+/**
+ * ソート可能なテーブル用のヘッダーラベル
+ */
+export default function CustomHeaderSortLabel({
+  title,
+  isSelected,
+  isAsc,
+  onClickTitle,
+}: Props) {
+  const { customDesign } = HeaderDesign({ isSelected });
+  return (
+    <ButtonBase onClick={() => onClickTitle(title)} sx={customDesign}>
+      <TableSortLabel
+        active={isSelected}
+        direction={isSelected && !isAsc ? "desc" : "asc"}
+      >
+        {title}
+      </TableSortLabel>
+    </ButtonBase>
+  );
+}

--- a/my-app/src/component/table/header/useHeaderLabelDesign.ts
+++ b/my-app/src/component/table/header/useHeaderLabelDesign.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+
+type Props = {
+  /** 選択状態 */
+  isSelected: boolean;
+};
+
+/**
+ * デザインに関するまとめ
+ */
+export default function useHeaderLabelDesign({ isSelected }: Props) {
+  const customDesign = useMemo(
+    () => ({
+      display: "inline-flex", // ラベルの大きさに合わせる
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: "16px", // 楕円っぽい形
+      padding: "4px 12px",
+      transition: "background-color 0.2s",
+      backgroundColor: isSelected ? "rgba(0, 0, 0, 0.07)" : "transparent",
+      "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.1)" }, // ホバー時にグレー
+      "&:active": { backgroundColor: "rgba(0, 0, 0, 0.2)" }, // クリック時に濃いグレー
+    }),
+    [isSelected]
+  );
+  return {
+    /** 選択状態によって変わるテーブルのデザイン(メモ化済み) */
+    customDesign,
+  };
+}

--- a/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/table/header/DailyTableHeader.tsx
@@ -1,12 +1,7 @@
-import {
-  ButtonBase,
-  TableCell,
-  TableHead,
-  TableRow,
-  TableSortLabel,
-  Typography,
-} from "@mui/material";
+import { TableCell, TableHead, TableRow, Typography } from "@mui/material";
 import { DailyTableHeaderLogic } from "./logic";
+import CustomHeaderSortLabel from "@/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel";
+import CustomHeaderSortCheckLabel from "@/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel";
 
 type Props = {
   /** 昇順かどうか */
@@ -29,10 +24,7 @@ export default function DailyTableHeader({
   isSelected,
   OnClickTitle,
 }: Props) {
-  const { headerColumnDisplay, getButtonDesign, getPopperIdRef } =
-    DailyTableHeaderLogic({
-      isSelected,
-    });
+  const { headerColumnDisplay, getPopperIdRef } = DailyTableHeaderLogic();
   return (
     <TableHead>
       <TableRow>
@@ -41,36 +33,24 @@ export default function DailyTableHeader({
           <TableCell key={title}>
             {/** メニューを表示しない場合(日付・合計稼働時間) */}
             {type == "none" && (
-              <ButtonBase
-                onClick={() => OnClickTitle(title)}
-                sx={getButtonDesign(title)}
-              >
-                <TableSortLabel
-                  active={isSelected(title)}
-                  direction={isSelected(title) && !isAsc ? "desc" : "asc"}
-                >
-                  {title}
-                </TableSortLabel>
-              </ButtonBase>
+              <CustomHeaderSortLabel
+                title={title}
+                isSelected={isSelected(title)}
+                isAsc={isAsc}
+                onClickTitle={OnClickTitle}
+              />
             )}
-
             {/** チェックボックスメニューを表示する場合(カテゴリ・タスク) */}
             {type == "checkbox" && (
-              <ButtonBase
-                onClick={() => OnClickTitle(title)}
-                onMouseEnter={(event) =>
-                  onHoverTitle(getPopperIdRef(title), event)
-                }
-                onMouseLeave={() => onLeaveHoverTitle(getPopperIdRef(title))}
-                sx={getButtonDesign(title)}
-              >
-                <TableSortLabel
-                  active={isSelected(title)}
-                  direction={isSelected(title) && !isAsc ? "desc" : "asc"}
-                >
-                  {title}
-                </TableSortLabel>
-              </ButtonBase>
+              <CustomHeaderSortCheckLabel
+                title={title}
+                isSelected={isSelected(title)}
+                isAsc={isAsc}
+                refId={getPopperIdRef(title)}
+                onClickTitle={OnClickTitle}
+                onHoverTitle={onHoverTitle}
+                onLeaveTitle={onLeaveHoverTitle}
+              />
             )}
             {/** メニュー表示もソートもできない(メモ) */}
             {type == "title" && <Typography>{title}</Typography>}

--- a/my-app/src/pages/work-log/daily/table/header/logic.ts
+++ b/my-app/src/pages/work-log/daily/table/header/logic.ts
@@ -1,13 +1,9 @@
 import { useCallback } from "react";
 
-type Props = {
-  /** タイトルが選択中かどうかを調べる関数 */
-  isSelected: (title: string) => boolean;
-};
 /**
  * 日付ページのテーブルコンポーネントのヘッダーのロジック
  */
-export const DailyTableHeaderLogic = ({ isSelected }: Props) => {
+export const DailyTableHeaderLogic = () => {
   const headerColumnDisplay = {
     日付: "none",
     メインカテゴリ: "checkbox",
@@ -15,27 +11,6 @@ export const DailyTableHeaderLogic = ({ isSelected }: Props) => {
     メモ: "title",
     合計稼働時間: "none",
   } as const;
-
-  /**
-   * テーブルメニューの選択かどうか:title==selectedTitle or checkSelected(title)で取得
-   * useMemoの場合：
-   */
-  const getButtonDesign = useCallback(
-    (title: string) => ({
-      display: "inline-flex", // ラベルの大きさに合わせる
-      alignItems: "center",
-      justifyContent: "center",
-      borderRadius: "16px", // 楕円っぽい形
-      padding: "4px 12px",
-      transition: "background-color 0.2s",
-      backgroundColor: isSelected(title)
-        ? "rgba(0, 0, 0, 0.07)"
-        : "transparent",
-      "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.1)" }, // ホバー時にグレー
-      "&:active": { backgroundColor: "rgba(0, 0, 0, 0.2)" }, // クリック時に濃いグレー
-    }),
-    [isSelected]
-  );
 
   const getPopperIdRef = useCallback(
     (title: string) => (title == "メインカテゴリ" ? 10000 : 10001),
@@ -45,8 +20,6 @@ export const DailyTableHeaderLogic = ({ isSelected }: Props) => {
   return {
     /** key:テーブルのタイトル名 value:ホバー時のメニュー表示の設定 のオブジェクト */
     headerColumnDisplay,
-    /** ボタンのデザイン情報を取得する関数 */
-    getButtonDesign,
     /** ポッパー用のidRefを取得する関数
      * メインカテゴリ:10000
      * メインタスク:10001


### PR DESCRIPTION
# 変更点
- テーブルヘッダーのソートしたりチェックボックスだしたりするやつ分離

# 詳細
- 共有Componentにソートラベルをそれぞれ分離して新規作成
  - 違うページでも使いたいので