### PR TITLE
ui:日付詳細ページテーブルヘッダー作成

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TaskTableHeader from './TaskTableHeader';
+
+const meta = {
+  component: TaskTableHeader,
+} satisfies Meta<typeof TaskTableHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isAsc: true,
+    isSelected: () => {},
+    OnClickTitle: () => {},
+    onHoverTitle: () => {},
+    onLeaveHoverTitle: () => {}
+  }
+};

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.tsx
@@ -1,0 +1,63 @@
+import { TableHead, TableRow, TableCell } from "@mui/material";
+import TaskTableHeaderLogic from "./TaskTableHeaderLogic";
+import CustomHeaderSortLabel from "@/component/table/header/CustomHeaderSortLabel/CustomHeaderSortLabel";
+import CustomHeaderSortCheckLabel from "@/component/table/header/CustomHeaderSortCheckLabel/CustomHeaderSortCheckLabel";
+
+type Props = {
+  /** 昇順かどうか */
+  isAsc: boolean;
+  /** 項目が選択中かどうか */
+  isSelected: (title: string) => boolean;
+  /** 表題をクリックした際のハンドラー */
+  OnClickTitle: (title: string) => void;
+  /** セルにホバー時のハンドラー */
+  onHoverTitle: (id: number, event: React.MouseEvent<HTMLElement>) => void;
+  /** セルにホバー解除時のハンドラー */
+  onLeaveHoverTitle: (id: number) => void;
+};
+
+/**
+ * 日付ページ詳細のタスク部分のテーブルのヘッダーコンポーネント
+ */
+export default function TaskTableHeader({
+  isAsc,
+  onHoverTitle,
+  onLeaveHoverTitle,
+  isSelected,
+  OnClickTitle,
+}: Props) {
+  const { headerColumnDisplay, getPopperIdRef, getWidth } =
+    TaskTableHeaderLogic();
+  return (
+    <TableHead>
+      <TableRow>
+        {Object.entries(headerColumnDisplay).map(([title, type]) => (
+          // 共通設定(パディングやサイズなど)
+          <TableCell key={title} width={getWidth(title)}>
+            {/** チェックボックスメニューを表示する場合(カテゴリ・タスク) */}
+            {type == "checkbox" && (
+              <CustomHeaderSortCheckLabel
+                title={title}
+                isSelected={isSelected(title)}
+                isAsc={isAsc}
+                refId={getPopperIdRef(title)}
+                onClickTitle={OnClickTitle}
+                onHoverTitle={onHoverTitle}
+                onLeaveTitle={onLeaveHoverTitle}
+              />
+            )}
+            {/** メニューを表示しない場合(合計稼働時間) */}
+            {type == "none" && (
+              <CustomHeaderSortLabel
+                title={title}
+                isSelected={isSelected(title)}
+                isAsc={isAsc}
+                onClickTitle={OnClickTitle}
+              />
+            )}
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeaderLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeaderLogic.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+
+/**
+ * 日付詳細ページのタスクテーブルのヘッダーコンポーネントのロジック
+ */
+export default function TaskTableHeaderLogic() {
+  const headerColumnDisplay: Record<string, string> = {
+    タスク名: "checkbox",
+    カテゴリ名: "checkbox",
+    稼働時間: "none",
+  };
+
+  const getPopperIdRef = useCallback(
+    (title: string) => (title == "タスク名" ? 10000 : 10001),
+    []
+  );
+
+  const getWidth = useCallback((title: string) => {
+    if (title == "タスク名") return "40%";
+    if (title == "カテゴリ名") return "35%";
+    if (title == "稼働時間") return "25%";
+  }, []);
+  return {
+    /** key:ヘッダーのタイトル,value:タイトルの種類(ソートの可否・フィルターの可否) */
+    headerColumnDisplay,
+    /** タイトルから固有のidを与える タスク名:10000,カテゴリ名：10001 */
+    getPopperIdRef,
+    /** そのタイトルの幅を取得する関数 */
+    getWidth,
+  };
+}


### PR DESCRIPTION
# 変更点
- ヘッダーのUI作成

# 詳細
- 基本的には一覧ページの使い回し