### PR TITLE
fix:オーバーフロー時にテーブルが崩れる問題

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeader.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import TaskTableHeader from './TaskTableHeader';
+import TaskTableHeader from "./TaskTableHeader";
 
 const meta = {
   component: TaskTableHeader,
@@ -13,9 +13,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     isAsc: true,
-    isSelected: () => {},
+    isSelected: () => false,
     OnClickTitle: () => {},
     onHoverTitle: () => {},
-    onLeaveHoverTitle: () => {}
-  }
+    onLeaveHoverTitle: () => {},
+  },
 };

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeaderLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/DailyDetailTaskTableHeader/TaskTableHeaderLogic.ts
@@ -16,9 +16,9 @@ export default function TaskTableHeaderLogic() {
   );
 
   const getWidth = useCallback((title: string) => {
-    if (title == "タスク名") return "40%";
+    if (title == "タスク名") return "45%";
     if (title == "カテゴリ名") return "35%";
-    if (title == "稼働時間") return "25%";
+    if (title == "稼働時間") return "20%";
   }, []);
   return {
     /** key:ヘッダーのタイトル,value:タイトルの種類(ソートの可否・フィルターの可否) */

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
@@ -14,8 +14,8 @@ const meta = {
       { id: 5, name: "タスク6", categoryName: "カテゴリー3", dailyHours: 4 },
       {
         id: 6,
-        name: "タスク1904",
-        categoryName: "カテゴリー11daw21",
+        name: "タスク19qwdqwfqfqfqqwdqwdwqwqsqwqdqdsadadadadasdasdadasdasdadasdassad04",
+        categoryName: "カテゴリー11sdwqqwdwdwqdwqdqwdqwdqdqwqddqwqddaw21",
         dailyHours: 8,
       },
     ],

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.tsx
@@ -42,7 +42,9 @@ export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
   return (
     <>
       <TableContainer>
-        <Table sx={{ width: "100%", padding: "16px 24px" }}>
+        <Table
+          sx={{ tableLayout: "fixed", width: "100%", padding: "16px 24px" }}
+        >
           <TaskTableHeader
             isAsc={isAsc}
             isSelected={isSelected}
@@ -82,8 +84,6 @@ export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
                     {/** タスク名 */}
                     <TableCell
                       sx={{
-                        width: "45%",
-                        maxWidth: "45%",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
@@ -94,8 +94,6 @@ export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
                     {/** カテゴリ */}
                     <TableCell
                       sx={{
-                        width: "35%",
-                        maxWidth: "35%",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
@@ -106,8 +104,6 @@ export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
                     {/** 稼働時間*/}
                     <TableCell
                       sx={{
-                        width: "25%",
-                        maxWidth: "25%",
                         overflow: "hidden",
                         whiteSpace: "nowrap",
                         textOverflow: "ellipsis",


### PR DESCRIPTION
# 変更点
- 長い文章がテーブルせるに挿入される際にレイアウトが崩れる問題を解決
- あと、storybookの修正を少し
# 詳細
- table-layoutにfixedを設定し幅を固定に
  - これにより、headerの大きさに全ての行が依存するように変更
    - 仕様により、初めて出現した行の幅を全ての行に適応するため
  - bodyのwidth関連のプロパティを削除(上記の通りの、ため)