### PR TITLE
refactor:TaskTableのストーリーブックのモックデータをdummyファイルに移動

### DIFF
--- a/my-app/src/dummy/daily-page.ts
+++ b/my-app/src/dummy/daily-page.ts
@@ -1,5 +1,6 @@
 import { DateSummary } from "@/type/Date";
 import { MemoTitleList } from "@/type/Memo";
+import { DailyDetailTaskTableType } from "@/type/Task";
 
 /**
  * 日付ページ一覧ページ用のダミーデータ
@@ -119,4 +120,19 @@ export const DUMMY_MEMO_LIST: MemoTitleList[] = [
   { id: 0, title: "メモ1" },
   { id: 1, title: "メモ2" },
   { id: 2, title: "メモ3" },
+];
+
+export const DUMMY_TASK_TABLE_LIST: DailyDetailTaskTableType[] = [
+  { id: 0, name: "タスク1", categoryName: "カテゴリー1", dailyHours: 8 },
+  { id: 1, name: "タスク2", categoryName: "カテゴリー1", dailyHours: 6 },
+  { id: 2, name: "タスク3", categoryName: "カテゴリー2", dailyHours: 8 },
+  { id: 3, name: "タスク4", categoryName: "カテゴリー2", dailyHours: 5 },
+  { id: 4, name: "タスク5", categoryName: "カテゴリー3", dailyHours: 3 },
+  { id: 5, name: "タスク6", categoryName: "カテゴリー3", dailyHours: 4 },
+  {
+    id: 6,
+    name: "タスク19qwdqwfqfqfqqwdqwdwqwqsqwqdqdsadadadadasdasdadasdasdadasdassad04",
+    categoryName: "カテゴリー11sdwqqwdwdwqdwqdqwdqwdqdqwqddqwqddaw21",
+    dailyHours: 8,
+  },
 ];

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
@@ -1,24 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import TaskTable from "./TaskTable";
+import { DUMMY_TASK_TABLE_LIST } from "@/dummy/daily-page";
 
 const meta = {
   component: TaskTable,
   args: {
-    taskList: [
-      { id: 0, name: "タスク1", categoryName: "カテゴリー1", dailyHours: 8 },
-      { id: 1, name: "タスク2", categoryName: "カテゴリー1", dailyHours: 6 },
-      { id: 2, name: "タスク3", categoryName: "カテゴリー2", dailyHours: 8 },
-      { id: 3, name: "タスク4", categoryName: "カテゴリー2", dailyHours: 5 },
-      { id: 4, name: "タスク5", categoryName: "カテゴリー3", dailyHours: 3 },
-      { id: 5, name: "タスク6", categoryName: "カテゴリー3", dailyHours: 4 },
-      {
-        id: 6,
-        name: "タスク19qwdqwfqfqfqqwdqwdwqwqsqwqdqdsadadadadasdasdadasdasdadasdassad04",
-        categoryName: "カテゴリー11sdwqqwdwdwqdwqdqwdqwdqdqwqddqwqddaw21",
-        dailyHours: 8,
-      },
-    ],
+    taskList: DUMMY_TASK_TABLE_LIST,
     isLoading: false,
     onClickRow: () => {},
   },


### PR DESCRIPTION
# 変更点
- TaskTableストーリーブックのモックデータをdummyデータとして移動

# 理由
- 他のストーリーブックないしmockデータとして使用する目的のため