### PR TITLE
feature:日付詳細ページ - タスクテーブルの選択中のアイテムのidをパラメータに追加

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/task-list/TaskList.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/TaskList.tsx
@@ -36,6 +36,7 @@ export default function TaskList({
           taskList={taskList}
           isLoading={isLoading}
           onClickRow={() => {}} // TODO:ろじっくつくるとき
+          selectedItemId={null}
         />
       </Stack>
       {/** TODO:　ここに編集用のダイアログ */}

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     taskList: DUMMY_TASK_TABLE_LIST,
     isLoading: false,
     onClickRow: () => {},
+    selectedItemId: null,
   },
 } satisfies Meta<typeof TaskTable>;
 
@@ -19,3 +20,4 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 export const Loading: Story = { args: { isLoading: true } };
 export const NoItem: Story = { args: { taskList: [] } };
+export const ItemSelected: Story = { args: { selectedItemId: 1 } };

--- a/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/table/TaskTable.tsx
@@ -20,12 +20,19 @@ type Props = {
   isLoading: boolean;
   /** rowをクリックした際のハンドラー */
   onClickRow: (id: number) => void;
+  /** 選択状態のアイテムid */
+  selectedItemId: number | null;
 };
 
 /**
  * 日付詳細ページのタスクテーブルのコンポーネント
  */
-export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
+export default function TaskTable({
+  taskList,
+  isLoading,
+  onClickRow,
+  selectedItemId,
+}: Props) {
   const {
     isAsc,
     taskFilterList,
@@ -77,6 +84,7 @@ export default function TaskTable({ taskList, isLoading, onClickRow }: Props) {
                     key={item.id}
                     hover
                     onClick={() => onClickRow(item.id)}
+                    selected={item.id === selectedItemId}
                     sx={{
                       cursor: "pointer",
                     }}


### PR DESCRIPTION
# 変更点
- テーブルの選択中のアイテムのidを引数に追加
- 選択中のアイテムをハイライトするように変更

# 詳細
- パラメータにselectedItemIdを追加
  - selectedItemIdとrowのitem.idが一致する場合にその行のselectedパラメータをtrueにすることで、ハイライト可能に
