### PR TITLE
type:日付詳細ページタスクテーブルの型定義を更新

### DIFF
--- a/my-app/src/type/Task.ts
+++ b/my-app/src/type/Task.ts
@@ -1,3 +1,4 @@
+import { CategoryOption } from "./Category";
 import { MemoSummary } from "./Memo";
 
 /** タスクの選択欄の型定義 */
@@ -51,10 +52,10 @@ export type TaskWithPercentage = { id: number; name: string; percent: string };
 export type DailyDetailTaskTableType = {
   /** 識別用(タスクの) */
   id: number;
-  /** タスク名 */
-  name: string;
-  /** カテゴリ名 */
-  categoryName: string;
+  /** タスク*/
+  task: TaskOption;
+  /** カテゴリ */
+  category: CategoryOption;
   /** 稼働時間 */
   dailyHours: number;
 };


### PR DESCRIPTION
# 変更点
 タイトル通り
# 詳細
- タスクとカテゴリの項目を変更
  - nameのみ -> idを含む構造体に変更
  - ページナビゲーション時に利用するため(タスク名の被りをある程度許容できるようにしたいから)