### PR TITLE
feature:エラーページのIDの定数を定義

### DIFF
--- a/my-app/src/constant/errorPages.ts
+++ b/my-app/src/constant/errorPages.ts
@@ -1,0 +1,4 @@
+/**
+ * エラーページ関連の定数のまとーめ
+ */
+export const ERROR_PAGE_ID = 404;


### PR DESCRIPTION
# 変更点
タイトル通り
# 詳細
- task/日付/カテゴリーページについて、ページが見つからなかった時のエラーページのidを定義
  - 404番を使用
  - そのため、各ページのidは連番を用いない方向で
  - (uiidとかでいいとおもう？かな)