### PR TITLE
feature:編集ダイアログと確認だいあろぐ繋ぎ込み

### DIFF
--- a/my-app/src/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/my-app/src/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -28,7 +28,14 @@ export default function ConfirmDeleteDialog({
       <DialogContent>
         <DialogContentText>削除してもよろしいですか？</DialogContentText>
         <DialogActions>
-          <Button onClick={onAccept}>はい</Button>
+          <Button
+            onClick={() => {
+              onAccept();
+              onClose();
+            }}
+          >
+            はい
+          </Button>
           <Button color="error" onClick={onClose}>
             いいえ
           </Button>

--- a/my-app/src/component/dialog/ConfirmSaveDialog/ConfirmSaveDialog.tsx
+++ b/my-app/src/component/dialog/ConfirmSaveDialog/ConfirmSaveDialog.tsx
@@ -24,7 +24,14 @@ export default function ConfirmSaveDialog({ open, onClose, onAccept }: Props) {
       <DialogContent>
         <DialogContentText>保存してもよろしいですか？</DialogContentText>
         <DialogActions>
-          <Button onClick={onAccept}>はい</Button>
+          <Button
+            onClick={() => {
+              onAccept();
+              onClose();
+            }}
+          >
+            はい
+          </Button>
           <Button color="error" onClick={onClose}>
             いいえ
           </Button>

--- a/my-app/src/hook/useDialog.ts
+++ b/my-app/src/hook/useDialog.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
  * ダイアログの基本構成
  */
 export default function useDialog() {
-  const [open, setOpen] = useState<boolean>();
+  const [open, setOpen] = useState<boolean>(false);
 
   const onClose = useCallback(() => setOpen(false), []);
   const onOpen = useCallback(() => setOpen(true), []);

--- a/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -11,6 +11,9 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import TaskEditDialogLogic from "./TaskEditDialogLogic";
+import ConfirmDeleteDialog from "@/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog";
+import ConfirmSaveDialog from "@/component/dialog/ConfirmSaveDialog/ConfirmSaveDialog";
+import useDialog from "@/hook/useDialog";
 
 type Props = {
   /** 今開いてる対象のデータのid */
@@ -47,63 +50,90 @@ export default function TaskEditDialog({
     initialCategoryId,
     initialTaskId,
   });
+  const {
+    open: openDelete,
+    onClose: onCloseDelete,
+    onOpen: onOpenDelete,
+  } = useDialog();
+  const {
+    open: openSave,
+    onClose: onCloseSave,
+    onOpen: onOpenSave,
+  } = useDialog();
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogContent>
-        <Stack spacing={3} mt={1}>
-          <FormControl fullWidth>
-            <InputLabel>カテゴリ</InputLabel>
-            <Select
-              value={String(categoryId)}
-              onChange={onChangeSelectCategory}
-              label="カテゴリ"
-            >
-              {categoryList.map((cat) => (
-                <MenuItem key={cat.id} value={cat.id}>
-                  {cat.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <FormControl fullWidth>
-            <InputLabel>タスク</InputLabel>
-            <Select
-              value={String(taskId)}
-              onChange={onChangeSelectTask}
-              label="タスク"
-            >
-              {taskList.map((task) => (
-                <MenuItem key={task.id} value={task.id} disabled={task.id == 0}>
-                  {task.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Stack>
-      </DialogContent>
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogContent>
+          <Stack spacing={3} mt={1}>
+            <FormControl fullWidth>
+              <InputLabel>カテゴリ</InputLabel>
+              <Select
+                value={String(categoryId)}
+                onChange={onChangeSelectCategory}
+                label="カテゴリ"
+              >
+                {categoryList.map((cat) => (
+                  <MenuItem key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>タスク</InputLabel>
+              <Select
+                value={String(taskId)}
+                onChange={onChangeSelectTask}
+                label="タスク"
+              >
+                {taskList.map((task) => (
+                  <MenuItem
+                    key={task.id}
+                    value={task.id}
+                    disabled={task.id == 0}
+                  >
+                    {task.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+        </DialogContent>
 
-      <Stack direction="row" justifyContent={"space-between"} py={2} px={4}>
-        <Stack>
-          <Button
-            startIcon={<DeleteIcon />}
-            color="error"
-            onClick={handleDelete} // TODO:実際はダイアログを開かせる
-          >
-            削除
-          </Button>
+        <Stack direction="row" justifyContent={"space-between"} py={2} px={4}>
+          <Stack>
+            <Button
+              startIcon={<DeleteIcon />}
+              color="error"
+              onClick={onOpenDelete}
+            >
+              削除
+            </Button>
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <Button onClick={onClose}>キャンセル</Button>
+            <Button
+              startIcon={<CheckCircleIcon />}
+              variant="contained"
+              disabled={unSelected}
+              onClick={onOpenSave}
+            >
+              保存
+            </Button>
+          </Stack>
         </Stack>
-        <Stack direction="row" spacing={2}>
-          <Button onClick={onClose}>キャンセル</Button>
-          <Button
-            startIcon={<CheckCircleIcon />}
-            variant="contained"
-            disabled={unSelected}
-            onClick={handleSave} // TODO:実際はダイアログを開かせる
-          >
-            保存
-          </Button>
-        </Stack>
-      </Stack>
-    </Dialog>
+      </Dialog>
+      {/** 確認ダイアログ */}
+      <ConfirmDeleteDialog
+        open={openDelete}
+        onClose={onCloseDelete}
+        onAccept={handleDelete}
+      />
+      <ConfirmSaveDialog
+        open={openSave}
+        onClose={onCloseSave}
+        onAccept={handleSave}
+      />
+    </>
   );
 }


### PR DESCRIPTION
# 変更点
- 編集ダイアログで確認ダイアログがひょうじできるように変更


# 詳細
- 編集ダイアログで保存/削除を選択した場合にダイアログが表示できるように変更
## 細かい修正
- useDialogカスタムフックのopenの初期値与え忘れ修正
- ダイアログのAccept時のonClickイベントでonCloseを追加(どちらの選択賜でも閉じるようにしたいので)