### PR TITLE
ui:編集ダイアログに時間の項目追加

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -97,6 +97,20 @@ export default function TaskEditDialog({
                 ))}
               </Select>
             </FormControl>
+            <FormControl sx={{ width: "30%" }}>
+              <InputLabel>稼働時間(hour)</InputLabel>
+              <Select
+                value={"8"} // TODO:しゅうせいすりゅ！
+                onChange={() => {}} // TODO:しゅーせい！
+                label="稼働時間(hour)"
+              >
+                {[...Array(41)].map((_, i) => (
+                  <MenuItem key={i} value={i * 0.25}>
+                    {i * 0.25}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Stack>
         </DialogContent>
 


### PR DESCRIPTION
# 変更点
タイトルの通り

# 詳細
- 0.25刻みで選択可能なセレクトをカテゴリのセレクトの下に配置
  - 機能面は未実装