### PR TITLE
feature:時間を編集できるように機能を変更

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/task-list/TaskList.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/TaskList.tsx
@@ -31,6 +31,7 @@ export default function TaskList({
     isItemSelected,
     selectedItemTaskId,
     selectedItemCategoryId,
+    selectedItemHours,
     handleClickRow,
   } = TaskListLogic({
     taskList,
@@ -61,6 +62,7 @@ export default function TaskList({
             itemId={selectedItemId}
             initialCategoryId={selectedItemCategoryId}
             initialTaskId={selectedItemTaskId}
+            initialHours={selectedItemHours}
             open={open}
             onClose={onClose}
           />

--- a/my-app/src/pages/work-log/daily/:id/task-list/TaskListLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/task-list/TaskListLogic.ts
@@ -26,6 +26,12 @@ export default function TaskListLogic({ taskList }: Props) {
     return ERROR_PAGE_ID;
   }, [selectedItemId, taskList]);
 
+  const selectedItemHours = useMemo(() => {
+    const target = taskList.find((item) => item.id === selectedItemId);
+    if (target) return target.dailyHours;
+    return 0;
+  }, [selectedItemId, taskList]);
+
   // ローカル--------------------------------------------------
   const doSelectItem = useCallback((id: number) => {
     setSelectedItemId(id);
@@ -61,6 +67,8 @@ export default function TaskListLogic({ taskList }: Props) {
     selectedItemTaskId,
     /** 選択中のアイテムのカテゴリーid */
     selectedItemCategoryId,
+    /** 選択中のアイテムの稼働時間 */
+    selectedItemHours,
     /** アイテムの行をクリックした際のハンドラー
      * アイテムを選択しているかどうかで選択/選択解除を行う
      */

--- a/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
     itemId: 0,
     initialTaskId: 1,
     initialCategoryId: 1,
+    initialHours: 8,
     open: true,
     onClose: () => {},
   },

--- a/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -24,6 +24,8 @@ type Props = {
   initialTaskId: number;
   /** ダイアログの開閉状態 */
   open: boolean;
+  /** 稼働時間の初期選択の値 */
+  initialHours: number;
   /** ダイアログ閉じるイベント */
   onClose: () => void;
 };
@@ -32,23 +34,27 @@ export default function TaskEditDialog({
   itemId,
   initialCategoryId,
   initialTaskId,
+  initialHours,
   open,
   onClose,
 }: Props) {
   const {
     categoryId,
     taskId,
+    dailyHours,
     unSelected,
     taskList,
     categoryList,
     onChangeSelectCategory,
     onChangeSelectTask,
+    onChangeSelectHours,
     handleSave,
     handleDelete,
   } = TaskEditDialogLogic({
     itemId,
     initialCategoryId,
     initialTaskId,
+    initialHours,
   });
   const {
     open: openDelete,
@@ -100,8 +106,8 @@ export default function TaskEditDialog({
             <FormControl sx={{ width: "30%" }}>
               <InputLabel>稼働時間(hour)</InputLabel>
               <Select
-                value={"8"} // TODO:しゅうせいすりゅ！
-                onChange={() => {}} // TODO:しゅーせい！
+                value={String(dailyHours)}
+                onChange={onChangeSelectHours}
                 label="稼働時間(hour)"
               >
                 {[...Array(41)].map((_, i) => (

--- a/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -10,6 +10,8 @@ type Props = {
   initialCategoryId: number;
   /** タスクidの初期選択の値 */
   initialTaskId: number;
+  /** 稼働時間の初期選択の値 */
+  initialHours: number;
 };
 
 /**
@@ -19,9 +21,11 @@ export default function TaskEditDialogLogic({
   itemId,
   initialCategoryId,
   initialTaskId,
+  initialHours,
 }: Props) {
   const [categoryId, setCategoryId] = useState<number>(initialCategoryId);
   const [taskId, setTaskId] = useState<number>(initialTaskId);
+  const [dailyHours, setDailyHours] = useState<number>(initialHours);
   const unSelected = categoryId === 0 || taskId === 0;
 
   // TODO:データフェッチ行う
@@ -50,6 +54,11 @@ export default function TaskEditDialogLogic({
     setTaskId(Number(target));
   }, []);
 
+  const onChangeSelectHours = useCallback((e: SelectChangeEvent) => {
+    const target = e.target.value;
+    setDailyHours(Number(target));
+  }, []);
+
   // TODO:バックエンドに送信
   const handleSave = useCallback(() => {
     console.log("せーぶ！ id:", itemId);
@@ -62,6 +71,8 @@ export default function TaskEditDialogLogic({
     categoryId,
     /** 選択中のタスクのid */
     taskId,
+    /** 洗濯中の稼働時間 */
+    dailyHours,
     /** 対象を選択していない状態 */
     unSelected,
     /** カテゴリ一覧 */
@@ -72,6 +83,8 @@ export default function TaskEditDialogLogic({
     onChangeSelectCategory,
     /** 選択したタスクに変更するハンドラー */
     onChangeSelectTask,
+    /** 選択した稼働時間に変更するハンドラー */
+    onChangeSelectHours,
     /** 編集を保存するハンドラー */
     handleSave,
     /** デリートのイベント */


### PR DESCRIPTION
# 変更点
- 時間を編集できる機能を追加

# 詳細
- 基本的にはタスクとかと一緒
  - 選択中のアイテムの稼働時間を取得し、表示
  - セレクトで稼働時間を選択可能
- onAccept時に送信するデータはのちのち考える

# 検討
- フォームの送信をonAcceptで送るのだけど、RHFを使うかどうか？state管理はかなりすっきりはする
-  ->ただ、どうせフォームいじった時に選択賜をfetchする必要があるので、いらないかなー？って感じはあり
  - 制御コンポーネントである方がこの場合は都合がいいので