### PR TITLE
type:日次詳細ページ用のメモのタイプを追加

### DIFF
--- a/my-app/src/type/Memo.ts
+++ b/my-app/src/type/Memo.ts
@@ -1,3 +1,5 @@
+import { TaskOption } from "./Task";
+
 /** タイトルとidだけのメモのデータ型 */
 export type MemoTitleList = {
   /** 識別用のid */
@@ -34,4 +36,16 @@ export type MemoDetail = {
   tag?: string;
   /** メモの本文 */
   text: string;
+};
+
+/** 日付タスクに付随するメモ */
+export type MemoDailyTask = {
+  /** 識別用のid */
+  id: number;
+  /** メモのタイトル */
+  title: string;
+  /** メモの本文の頭の方だけ */
+  summary: string;
+  /** 関連する日付のタスク */
+  task: TaskOption;
 };


### PR DESCRIPTION
概要はタイトル通り

# 詳細
- 日付ページ用のメモの型定義追加
  - 識別用のid
  - 表示用のタイトル/タスク名
  - (タスクリストでアイテム選択時)フィルター用のタスクid
  - row展開時に表示する本文の一部 summary