### PR TITLE
refactor:テーブルのロード中の表示を切り出してファイル化

### DIFF
--- a/my-app/src/component/table/body/TableBodyLoading/TableBodyLoading.stories.tsx
+++ b/my-app/src/component/table/body/TableBodyLoading/TableBodyLoading.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TableBodyLoading from './TableBodyLoading';
+
+const meta = {
+  component: TableBodyLoading,
+} satisfies Meta<typeof TableBodyLoading>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    colCount: 0
+  }
+};

--- a/my-app/src/component/table/body/TableBodyLoading/TableBodyLoading.tsx
+++ b/my-app/src/component/table/body/TableBodyLoading/TableBodyLoading.tsx
@@ -1,0 +1,19 @@
+import { TableRow, TableCell, CircularProgress } from "@mui/material";
+
+type Props = {
+  /** 行数 */
+  colCount: number;
+};
+
+/**
+ * ロード中に表示するテーブルボディコンポーネント
+ */
+export default function TableBodyLoading({ colCount }: Props) {
+  return (
+    <TableRow>
+      <TableCell colSpan={colCount} sx={{ height: "200px" }} align="center">
+        <CircularProgress />
+      </TableCell>
+    </TableRow>
+  );
+}


### PR DESCRIPTION
# 詳細
- ロード中の表示をコンポーネントに切り出し
  - 高さや寄りなどのスタイルを全体で合致させる目的
  - 行数だけ入力すれば自動的にテーブル中央付近にロードのインジケータを表示可能

# 注意点
- このPR内では切り出しのみを行っています
  - マージ後、該当する部分をこのコンポーネントで上書きする予定です