### PR TITLE
refactor:データがない時のテーブルボディを分離

### DIFF
--- a/my-app/src/component/table/body/TableBodyNoItem/TableBodyNoItem.stories.tsx
+++ b/my-app/src/component/table/body/TableBodyNoItem/TableBodyNoItem.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TableBodyNoItem from './TableBodyNoItem';
+
+const meta = {
+  component: TableBodyNoItem,
+} satisfies Meta<typeof TableBodyNoItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    colCount: 0
+  }
+};

--- a/my-app/src/component/table/body/TableBodyNoItem/TableBodyNoItem.tsx
+++ b/my-app/src/component/table/body/TableBodyNoItem/TableBodyNoItem.tsx
@@ -1,0 +1,19 @@
+import { TableRow, TableCell } from "@mui/material";
+
+type Props = {
+  /** 行数 */
+  colCount: number;
+};
+
+/**
+ * アイテムがない時のテーブルボディコンポーネント
+ */
+export default function TableBodyNoItem({ colCount }: Props) {
+  return (
+    <TableRow>
+      <TableCell colSpan={colCount} align="center" sx={{ height: "200px" }}>
+        データがありません
+      </TableCell>
+    </TableRow>
+  );
+}


### PR DESCRIPTION
タイトル通り

# 詳細
- データがない場合のテーブルの表示
  - 行数だけ指定すればテーブル中央に文章を表示する

# 注意点
- このPRでは分離したファイルのみを作成
  - PRマージ後、それぞれに適応させる予定