### PR TITLE
type:ソート対象のリテラル型の型定義を追加

### DIFF
--- a/my-app/src/hook/useTableSort.ts
+++ b/my-app/src/hook/useTableSort.ts
@@ -1,3 +1,4 @@
+import { TableSortTargetType } from "@/type/Table";
 import { useCallback, useState } from "react";
 
 type Props = {
@@ -33,7 +34,7 @@ export default function useTableSort({ initialTarget }: Props) {
 
   // ソート関数
   const doSort = useCallback(
-    (a: string | number | Date, b: string | number | Date) => {
+    (a: TableSortTargetType, b: TableSortTargetType) => {
       switch (typeof a) {
         // 各タイプの同定を行ったのちにソートする
         case "string":

--- a/my-app/src/type/Table.ts
+++ b/my-app/src/type/Table.ts
@@ -1,0 +1,4 @@
+/**
+ * テーブルのソート対象のタイプ
+ */
+export type TableSortTargetType = string | number | Date;


### PR DESCRIPTION
変更点はタイトル通り

# 詳細
- ソート時の型定義を分離
  - ソート対象が増えた場合に対応が楽になるように定義