### PR TITLE
fix:しゅうせい

### DIFF
--- a/my-app/src/hook/useTableSort.ts
+++ b/my-app/src/hook/useTableSort.ts
@@ -26,15 +26,15 @@ export default function useTableSort({ initialTarget }: Props) {
       } else {
         // 非選択の場合:新たなターゲットをセットする
         setTarget(title);
+        setIsAsc(true);
       }
-      setIsAsc(true);
     },
     [isAsc, isSelected]
   );
 
   // ソート関数
   const doSort = useCallback(
-    (a: TableSortTargetType, b: TableSortTargetType) => {
+    ({ a, b }: { a: TableSortTargetType; b: TableSortTargetType }) => {
       switch (typeof a) {
         // 各タイプの同定を行ったのちにソートする
         case "string":


### PR DESCRIPTION
# 変更点
- 引数修正
- 関数の修正

# 詳細
- sort関数の引数を2つ => オブジェクト1つにまとめ
  - sort時の都合で
- handleClickSortLabelの条件分岐のset関数が外に出てたので修正