### PR TITLE
fix:paramの型と初期値みすってたので修正

### DIFF
--- a/my-app/src/hook/useTableSort.ts
+++ b/my-app/src/hook/useTableSort.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 
 type Props = {
   /** 初期選択項目 */
-  initialTarget: string;
+  initialTarget: string | null;
 };
 
 /**
@@ -12,7 +12,7 @@ type Props = {
  */
 export default function useTableSort({ initialTarget }: Props) {
   const [isAsc, setIsAsc] = useState<boolean>(true);
-  const [target, setTarget] = useState<string | null>(() => initialTarget);
+  const [target, setTarget] = useState<string | null>(initialTarget);
 
   // タイトルが選択状態かどうかを調べる関数
   const isSelected = useCallback((title: string) => target === title, [target]);


### PR DESCRIPTION
# 変更点
- paramの型定義を修正
- stateの初期値を修正

# 詳細
- 引数 initialTargetの型をnull許容
  - メモだとnullにするため
  - そもそもnull想定だったので(stateの方はnull許容だし)
- targetについてのuseStateの初期値を変更
  - 元々はオブジェクトを渡すのを検討していた名残
  - 今はstringなので、そのまま渡すように修正