### PR TITLE
ui:ボディborderの線が気になったのでちょい変更

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/memo-list/table-body/CustomTableBody.tsx
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/table-body/CustomTableBody.tsx
@@ -45,7 +45,7 @@ export default function CustomTableBody({
           {memoItem.task.name}
         </TableCell>
       </TableRow>
-      <TableRow>
+      <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={2}>
           <Collapse in={isActive} timeout="auto" unmountOnExit>
             <Box margin={1}>{memoItem.summary}</Box>


### PR DESCRIPTION
概要はタイトル通り

# 詳細
- Bodyのアイテムごとの線の太さが他のTableと比べて太いのを修正
  - Collapseの折りたたんでるRowの線が被ってたのが原因
  -  => ので、Collaspeの方のRowの線をborderBottom: "unset"でセット
    - Row内のCellの方にも適応するために "& > *"で子全てにも同じスタイルを適応