### PR TITLE
ui:ツールチップの見た目完成

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/circle-graph/tool-chip/CircleGraphToolChip.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/circle-graph/tool-chip/CircleGraphToolChip.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import CircleGraphToolChip from "./CircleGraphToolChip";
+
+const meta = {
+  component: CircleGraphToolChip,
+  args: {
+    active: true,
+    payload: [
+      {
+        payload: {
+          name: "カテゴリ1",
+          value: 400,
+          task: [
+            { id: 1, name: "タスク1", percent: "40%" },
+            { id: 2, name: "タスク2", percent: "30%" },
+            { id: 3, name: "タスク3", percent: "30%" },
+          ],
+        },
+      },
+    ],
+  },
+} satisfies Meta<typeof CircleGraphToolChip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/my-app/src/pages/work-log/daily/:id/circle-graph/tool-chip/CircleGraphToolChip.tsx
+++ b/my-app/src/pages/work-log/daily/:id/circle-graph/tool-chip/CircleGraphToolChip.tsx
@@ -1,0 +1,31 @@
+import { TaskWithPercentage } from "@/type/Task";
+import { Paper, Stack, Typography } from "@mui/material";
+import { TooltipProps } from "recharts";
+
+/**
+ * 円グラフにホバー時に表示するツールチップのコンポーネント
+ */
+export default function CircleGraphToolChip({
+  active, // 引数はPieからToolChipで受け取る特有のもの
+  payload, // active:boolean,payload:Array([0].payloadに対象のデータがある)
+}: TooltipProps<number, string>) {
+  if (active && payload && payload.length > 0) {
+    const dataItem = payload[0].payload; // ← ここで Pie の 1つの data を取得！
+    return (
+      <Paper sx={{ px: 5, py: 1 }}>
+        {dataItem.task.map((item: TaskWithPercentage) => (
+          <Stack
+            mb={1}
+            key={item.id}
+            direction="row"
+            justifyContent={"space-between"}
+          >
+            <Typography>{item.name}</Typography>
+            <Typography>{item.percent}</Typography>
+          </Stack>
+        ))}
+      </Paper>
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
変更点はタイトル通り

# 詳細
- 円グラフでホバー時に表示されるツールチップの見た目作成
  - 組み込み時に微調整いるかも？わからん
- ツールチップの引数はToolChipコンポーネントのcontentプロパティで自動的に渡される値
  - 今ホバーしてる対象のデータを自動的にとってきてくれるぽい