### PR TITLE
ui:メモ追加ダイアログ

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import MemoAddDialog from "./MemoAddDialog";
+
+const meta = {
+  component: MemoAddDialog,
+  args: {
+    taskList: [
+      { id: 1, name: "タスク1" },
+      { id: 2, name: "タスク2" },
+      { id: 3, name: "タスク3" },
+      { id: 4, name: "タスク4" },
+      { id: 5, name: "タスク5" },
+    ],
+
+    tagList: [
+      { id: 0, name: "なし" },
+      { id: 1, name: "タグ1" },
+      { id: 2, name: "タグ2" },
+      { id: 3, name: "タグ3" },
+    ],
+    open: true,
+    onClose: () => {},
+    isTaskSelected: false,
+  },
+} satisfies Meta<typeof MemoAddDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const TaskFixed: Story = { args: { isTaskSelected: true } };

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
@@ -1,0 +1,87 @@
+import { TagOption } from "@/type/Tag";
+import { TaskOption } from "@/type/Task";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@mui/material";
+import NoteAddIcon from "@mui/icons-material/NoteAdd";
+
+type Props = {
+  /** タスクの一覧 */
+  taskList: TaskOption[];
+  /** タグの一覧 */
+  tagList: TagOption[];
+  /** ダイアログ開閉状態 */
+  open: boolean;
+  /** タスクを指定しているかどうか */
+  isTaskSelected: boolean;
+  /** ダイアログ閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * 日付詳細 メモを追加するためのダイアログ
+ */
+export default function MemoAddDialog({
+  taskList,
+  tagList,
+  open,
+  isTaskSelected,
+  onClose,
+}: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>メモを追加</DialogTitle>
+      {/** タスクの選択フォーム */}
+      <Stack spacing={1} px={2}>
+        <FormControl fullWidth>
+          <InputLabel>タスクを選ぶ</InputLabel>
+          {!isTaskSelected && (
+            <Select label="タスクを選ぶ" defaultValue={taskList[0].id}>
+              {taskList.map((task) => (
+                <MenuItem key={task.id} value={task.id}>
+                  {task.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+          {isTaskSelected && (
+            <Select disabled label="タスクを選ぶ" defaultValue={taskList[0].id}>
+              <MenuItem value={taskList[0].id}>{taskList[0].name}</MenuItem>
+            </Select>
+          )}
+        </FormControl>
+        {/** タイトル/タグ */}
+        <Stack direction="row" spacing={1}>
+          <TextField label="タイトル" sx={{ width: "80%" }} />
+          <FormControl sx={{ width: "20%" }}>
+            <InputLabel>タグ</InputLabel>
+            <Select label="タグ" defaultValue={tagList[0].id}>
+              {tagList.map((tag) => (
+                <MenuItem key={tag.id} value={tag.id}>
+                  {tag.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+        {/**　本文 */}
+        <TextField label="本文" multiline rows={4} />
+      </Stack>
+      <DialogActions>
+        <Button color="error">キャンセル</Button>
+        <Button variant="contained" startIcon={<NoteAddIcon />}>
+          追加
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# 変更点
-  日付詳細ページ　メモ追加ダイアログ作成

# 詳細
- 各フォームについて
## タスク
- タスク一覧から選択
- タスクを指定してメモを追加した場合は選択不可能
## メモ
- タイトルはTextFieldで
- タグはセレクトから選択
- 本文は4行のスペースをとって表示
  - ４行以上書く場合はスクロール可能

# 注意事項
- RHFでまとめて送信できるようにする予定なので、各フォームではvalueの代わりにdefaultValueを使用して非制御コンポーネントにしています。
  - みすって制御コンポーネントにしたらごめん！