### PR TITLE
ui:日付詳細 - タスク追加ダイアログ

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import TaskAddDialog from "./TaskAddDialog";
+
+const meta = {
+  component: TaskAddDialog,
+  args: {
+    categoryList: [
+      { id: 1, name: "カテゴリ1" },
+      { id: 2, name: "カテゴリ2" },
+      { id: 3, name: "カテゴリ3" },
+      { id: 4, name: "カテゴリ4" },
+    ],
+    taskList: [
+      { id: 1, name: "タスク1" },
+      { id: 2, name: "タスク2" },
+      { id: 3, name: "タスク3" },
+      { id: 4, name: "タスク4" },
+    ],
+    open: true,
+    onClose: () => {},
+    isLoading: false,
+  },
+} satisfies Meta<typeof TaskAddDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const NoTask: Story = { args: { taskList: [] } };
+export const Loading: Story = { args: { isLoading: true } };

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
@@ -1,0 +1,107 @@
+import { CategoryOption } from "@/type/Category";
+import { TaskOption } from "@/type/Task";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+} from "@mui/material";
+import AddTaskIcon from "@mui/icons-material/AddTask";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+
+type Props = {
+  /** カテゴリ一覧 */
+  categoryList: CategoryOption[];
+  /** タスク一覧 */
+  taskList: TaskOption[];
+  /** ロード状態(カテゴリーを変えた時に再度タスク一覧を取得する場合) */
+  isLoading: boolean;
+  /** ダイアログの開閉状態 */
+  open: boolean;
+  /** ダイアログを閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * 日付詳細 - タスクを追加するダイアログのコンポーネント
+ */
+export default function TaskAddDialog({
+  categoryList,
+  taskList,
+  isLoading,
+  open,
+  onClose,
+}: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>タスクを追加する</DialogTitle>
+      {/**コンテンツの部分 */}
+      <Stack px={2} spacing={1}>
+        {/** カテゴリのところ */}
+        <Stack direction="row" spacing={1}>
+          {/** セレクト*/}
+          <FormControl fullWidth>
+            <InputLabel>カテゴリ名</InputLabel>
+            <Select label="カテゴリ名" defaultValue={categoryList[0].id}>
+              {categoryList.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {/** 追加ボタン */}
+          <IconButton sx={{ width: 50, height: 50 }}>
+            <AddCircleOutlineIcon />
+          </IconButton>
+        </Stack>
+        {/** タスクのところ */}
+        <Stack direction="row" spacing={1}>
+          {/** セレクト */}
+          <FormControl fullWidth>
+            <InputLabel>タスク名</InputLabel>
+            {isLoading && (
+              <Select disabled label="タスク名" defaultValue={0}>
+                <MenuItem value={0}>
+                  <CircularProgress size={22} />
+                </MenuItem>
+              </Select>
+            )}
+            {!isLoading && taskList.length === 0 && (
+              <Select disabled label="タスク名" defaultValue={0}>
+                <MenuItem value={0}>タスクがありません</MenuItem>
+              </Select>
+            )}
+            {!isLoading && taskList.length > 0 && (
+              <Select label="タスク名" defaultValue={taskList[0].id}>
+                {taskList.map((task) => (
+                  <MenuItem key={task.id} value={task.id}>
+                    {task.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            )}
+          </FormControl>
+          {/** アイコンボタン */}
+          <IconButton sx={{ width: 50, height: 50 }}>
+            <AddCircleOutlineIcon />
+          </IconButton>
+        </Stack>
+      </Stack>
+      {/** ボタン */}
+      <DialogActions>
+        <Button color="error">キャンセル</Button>
+        <Button variant="contained" startIcon={<AddTaskIcon />}>
+          追加
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
変更点はタイトル通り

# 詳細
- カテゴリ
  - セレクトで選択
  - 隣のアイコンボタンでカテゴリ追加を行える
- タスク
  - いっしょ
  - カテゴリ内にタスクがない場合はdisabledにするみたいな感じにできる