### PR TITLE
feature:タスク追加ダイアログのフォームのロジック関係

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.stories.tsx
@@ -5,21 +5,8 @@ import TaskAddDialog from "./TaskAddDialog";
 const meta = {
   component: TaskAddDialog,
   args: {
-    categoryList: [
-      { id: 1, name: "カテゴリ1" },
-      { id: 2, name: "カテゴリ2" },
-      { id: 3, name: "カテゴリ3" },
-      { id: 4, name: "カテゴリ4" },
-    ],
-    taskList: [
-      { id: 1, name: "タスク1" },
-      { id: 2, name: "タスク2" },
-      { id: 3, name: "タスク3" },
-      { id: 4, name: "タスク4" },
-    ],
     open: true,
     onClose: () => {},
-    isLoading: false,
   },
 } satisfies Meta<typeof TaskAddDialog>;
 
@@ -28,5 +15,3 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-export const NoTask: Story = { args: { taskList: [] } };
-export const Loading: Story = { args: { isLoading: true } };

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
@@ -1,5 +1,3 @@
-import { CategoryOption } from "@/type/Category";
-import { TaskOption } from "@/type/Task";
 import {
   Button,
   CircularProgress,
@@ -15,14 +13,9 @@ import {
 } from "@mui/material";
 import AddTaskIcon from "@mui/icons-material/AddTask";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import TaskAddDialogLogic from "./TaskAddDialogLogic";
 
 type Props = {
-  /** カテゴリ一覧 */
-  categoryList: CategoryOption[];
-  /** タスク一覧 */
-  taskList: TaskOption[];
-  /** ロード状態(カテゴリーを変えた時に再度タスク一覧を取得する場合) */
-  isLoading: boolean;
   /** ダイアログの開閉状態 */
   open: boolean;
   /** ダイアログを閉じる関数 */
@@ -32,13 +25,17 @@ type Props = {
 /**
  * 日付詳細 - タスクを追加するダイアログのコンポーネント
  */
-export default function TaskAddDialog({
-  categoryList,
-  taskList,
-  isLoading,
-  open,
-  onClose,
-}: Props) {
+export default function TaskAddDialog({ open, onClose }: Props) {
+  const {
+    categoryList,
+    taskList,
+    isLoading,
+    selectedCategoryId,
+    selectedTaskId,
+    onChangeSelectedCategory,
+    onChangeSelectedTask,
+    handleAddDailyTask,
+  } = TaskAddDialogLogic();
   return (
     <Dialog open={open} onClose={onClose} fullWidth>
       <DialogTitle>タスクを追加する</DialogTitle>
@@ -49,7 +46,11 @@ export default function TaskAddDialog({
           {/** セレクト*/}
           <FormControl fullWidth>
             <InputLabel>カテゴリ名</InputLabel>
-            <Select label="カテゴリ名" defaultValue={categoryList[0].id}>
+            <Select
+              label="カテゴリ名"
+              value={String(selectedCategoryId)}
+              onChange={onChangeSelectedCategory}
+            >
               {categoryList.map((category) => (
                 <MenuItem key={category.id} value={category.id}>
                   {category.name}
@@ -68,19 +69,23 @@ export default function TaskAddDialog({
           <FormControl fullWidth>
             <InputLabel>タスク名</InputLabel>
             {isLoading && (
-              <Select disabled label="タスク名" defaultValue={0}>
+              <Select disabled label="タスク名" value={0}>
                 <MenuItem value={0}>
                   <CircularProgress size={22} />
                 </MenuItem>
               </Select>
             )}
             {!isLoading && taskList.length === 0 && (
-              <Select disabled label="タスク名" defaultValue={0}>
+              <Select disabled label="タスク名" value={0}>
                 <MenuItem value={0}>タスクがありません</MenuItem>
               </Select>
             )}
             {!isLoading && taskList.length > 0 && (
-              <Select label="タスク名" defaultValue={taskList[0].id}>
+              <Select
+                label="タスク名"
+                value={String(selectedTaskId)}
+                onChange={onChangeSelectedTask}
+              >
                 {taskList.map((task) => (
                   <MenuItem key={task.id} value={task.id}>
                     {task.name}
@@ -97,8 +102,15 @@ export default function TaskAddDialog({
       </Stack>
       {/** ボタン */}
       <DialogActions>
-        <Button color="error">キャンセル</Button>
-        <Button variant="contained" startIcon={<AddTaskIcon />}>
+        <Button color="error" onClick={onClose}>
+          キャンセル
+        </Button>
+        <Button
+          disabled={isLoading}
+          variant="contained"
+          startIcon={<AddTaskIcon />}
+          onClick={handleAddDailyTask}
+        >
           追加
         </Button>
       </DialogActions>

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialogLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/TaskAddDialog/TaskAddDialogLogic.ts
@@ -1,0 +1,62 @@
+import { CategoryOption } from "@/type/Category";
+import { TaskOption } from "@/type/Task";
+import { SelectChangeEvent } from "@mui/material";
+import { useCallback, useState } from "react";
+
+/**
+ * タスク追加ダイアログのロジック
+ */
+export default function TaskAddDialogLogic() {
+  // TODO:でーたふぇっちさせる
+  const categoryList: CategoryOption[] = [
+    { id: 1, name: "カテゴリ1" },
+    { id: 2, name: "カテゴリ2" },
+    { id: 3, name: "カテゴリ3" },
+    { id: 4, name: "カテゴリ4" },
+  ];
+  const taskList: TaskOption[] = [
+    { id: 0, name: "タスクがありません" },
+    { id: 1, name: "タスク1" },
+    { id: 2, name: "タスク2" },
+    { id: 3, name: "タスク3" },
+    { id: 4, name: "タスク4" },
+  ];
+  const isLoading = false;
+
+  // TODO:初期値はデータフェッチ時に設定させるようにuseEffectで条件分岐を作成しておこなう
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number>(1);
+  const [selectedTaskId, setSelectedTaskId] = useState<number>(0);
+
+  const onChangeSelectedCategory = useCallback(async (e: SelectChangeEvent) => {
+    const newValue = e.target.value;
+    setSelectedCategoryId(Number(newValue));
+    // TODO:カテゴリー変更時にタスクを再フェッチしてその後セットさせる
+  }, []);
+
+  const onChangeSelectedTask = useCallback((e: SelectChangeEvent) => {
+    const newValue = e.target.value;
+    setSelectedTaskId(Number(newValue));
+  }, []);
+
+  const handleAddDailyTask = useCallback(async () => {
+    // TODO:BEにデータ送信(selectedCategoryIdとタスクのそれを送信して送る)
+  }, []);
+  return {
+    /** カテゴリ一覧 */
+    categoryList,
+    /** タスク一覧 */
+    taskList,
+    /** ロード状態 */
+    isLoading,
+    /** 選択中のカテゴリID */
+    selectedCategoryId,
+    /** 選択中のタスクID */
+    selectedTaskId,
+    /** 選択中のカテゴリーを変更する関数 */
+    onChangeSelectedCategory,
+    /** 選択中のタスクを変更する関数 */
+    onChangeSelectedTask,
+    /** 日付のタスクを追加する関数 */
+    handleAddDailyTask,
+  };
+}


### PR DESCRIPTION
# 変更点
- タスク追加ダイアログのフォームのロジック追加

# 詳細
- タスクとカテゴリのセレクトについて
  - useStateで管理(useFormでやろうと思ったけど、やめた)
    - カテゴリ変更時にタスクのリストを再取得する必要があるため つまり制御される必要がある
- タスク一覧・カテゴリ一覧について
  - ここで取得
  - レンダーされるまで(open=trueになるまで)はフェッチされない、はず！　なので問題ないはず