### PR TITLE
feature:タスク追加ダイアログを作成

### DIFF
--- a/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialog.stories.tsx
+++ b/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialog.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import CreateTaskDialog from "./CreateTaskDialog";
+
+const meta = {
+  component: CreateTaskDialog,
+  args: {
+    initialCategoryId: 1,
+    open: true,
+    onClose: () => {},
+  },
+} satisfies Meta<typeof CreateTaskDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialog.tsx
+++ b/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialog.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Controller } from "react-hook-form";
+import AddTaskIcon from "@mui/icons-material/AddTask";
+import CreateTaskDialogLogic from "./CreateTaskDialogLogic";
+
+type Props = {
+  /** カテゴリidの初期値 */
+  initialCategoryId: number;
+  /** ダイアログ開閉状態 */
+  open: boolean;
+  /** ダイアログ閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * タスクを新規作成するダイアログ
+ */
+export default function CreateTaskDialog({
+  initialCategoryId,
+  open,
+  onClose,
+}: Props) {
+  const { categoryList, control, isValid, duplicateError, onSubmit } =
+    CreateTaskDialogLogic({
+      initialCategoryId,
+      onClose,
+    });
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>新規タスクを作成</DialogTitle>
+      <form onSubmit={onSubmit}>
+        {/** メインコンテンツ部分(カテゴリとタスク名のフォーム) */}
+        <Stack spacing={1} px={2}>
+          {/** カテゴリフォーム */}
+          <FormControl fullWidth>
+            <InputLabel>カテゴリ名</InputLabel>
+            <Controller
+              name="categoryId"
+              control={control}
+              render={({ field }) => (
+                <Select {...field} label="カテゴリ名">
+                  {categoryList.map((category) => (
+                    <MenuItem key={category.id} value={category.id}>
+                      {category.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+          </FormControl>
+          {/** タスク名のフォーム */}
+          <Controller
+            name="taskName"
+            control={control}
+            rules={{ required: true }}
+            render={({ field }) => (
+              <TextField {...field} label="タスク名" error={duplicateError} />
+            )}
+          />
+        </Stack>
+        {/** まんなか(エラーメッセージ) */}
+        {duplicateError && (
+          <Typography variant="caption" color="error">
+            * すでに同じタスク名が存在します。
+          </Typography>
+        )}
+        {/** ロウワー部分(おきにのチェックとボタン) */}
+        <Stack
+          spacing={1}
+          p={2}
+          direction="row"
+          justifyContent={"space-between"}
+        >
+          {/** おきにのチェック */}
+          <FormControl>
+            <FormControlLabel
+              control={
+                <Controller
+                  name="isFavorite"
+                  control={control}
+                  render={({ field }) => <Checkbox {...field} />}
+                />
+              }
+              label="お気に入りに設定"
+            />
+          </FormControl>
+          {/** 追加/キャンセルボタン */}
+          <Stack direction="row" spacing={2}>
+            <Button color="error" onClick={onClose}>
+              キャンセル
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<AddTaskIcon />}
+              type="submit"
+              disabled={!isValid}
+            >
+              追加
+            </Button>
+          </Stack>
+        </Stack>
+      </form>
+    </Dialog>
+  );
+}

--- a/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
+++ b/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
@@ -1,0 +1,78 @@
+import { CategoryOption } from "@/type/Category";
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+
+type SubmitData = {
+  /** カテゴリID */
+  categoryId: number;
+  /** タスク名 */
+  taskName: string;
+  /** お気に入りにするか */
+  isFavorite: boolean;
+};
+
+type Props = {
+  /** カテゴリidの初期値 */
+  initialCategoryId: number;
+  /** ダイアログ閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * タスクを新規作成するダイアログのロジック
+ */
+export default function CreateTaskDialogLogic({
+  initialCategoryId,
+  onClose,
+}: Props) {
+  // TODO:でーたふぇっちさせる
+  const categoryList: CategoryOption[] = [
+    { id: 1, name: "カテゴリ1" },
+    { id: 2, name: "カテゴリ2" },
+    { id: 3, name: "カテゴリ3" },
+    { id: 4, name: "カテゴリ4" },
+  ];
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<SubmitData>({
+    defaultValues: {
+      categoryId: initialCategoryId,
+      taskName: "",
+      isFavorite: false,
+    },
+  });
+  const [duplicateError, setDuplicateError] = useState<boolean>();
+  const onSubmit = useCallback(
+    async (data: SubmitData) => {
+      try {
+        // TODO:POSTリクエスト送る
+        console.log("でーた", data);
+        // TODO: ここでエラーハンドリング(response.okとかで)
+        if (true) {
+          onClose();
+        } else {
+          throw new Error();
+        }
+      } catch (error) {
+        // TODO:エラーの内容があらかじめ設定したものであればset
+        if (error) setDuplicateError(true);
+      }
+    },
+    [onClose]
+  );
+
+  return {
+    /** カテゴリの一覧 */
+    categoryList,
+    /** RHFのコントロールオブジェクト(MUIコンポーネントに必須) */
+    control,
+    /** フォームのバリデーション(タスク名の必須だけ？かな) */
+    isValid,
+    /** 重複エラー(同じカテゴリーに同じタスクがある場合のエラー) */
+    duplicateError,
+    /** 確定時のハンドラー */
+    onSubmit: handleSubmit(onSubmit),
+  };
+}


### PR DESCRIPTION
変更点はタイトル通り

# 詳細
- 一応共有のとこに作成
  - 多分使いまわせる　と思う
- useFormで3つのフォームを管理
  - カテゴリ：categoryIdを取得して送信(特に設定はしてないけど、実質的な必須項目)
  - タスク名：taskNameとしてstringを送信(必須項目)
  - オキニのチェック：isFavoriteとしてbooleanを送信
- タスク名が空欄の場合にのみ「追加」ボタンをisValidでdisabledに変更

## BE繋ぎ込み後の動作関連
- エラーハンドリング
  - 同カテゴリ内に同名タスクがある場合にエラーを返させてメッセージを表示させる
    - とりあえず作ったけど後々不要なら削除
    - いるようなら場合に合わせてデザインは調整