### PR TITLE
型定義を更新(あとデータ変換も)

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/page.tsx
+++ b/my-app/src/pages/work-log/daily/:id/page.tsx
@@ -8,7 +8,7 @@ import MemoList from "./memo-list/MemoList";
  * 日付詳細ページ
  */
 export default function DailyDetailPage() {
-  const { isLoading, date, dailyHours, memoList, circleDataList } =
+  const { isLoading, date, dailyHours, memoList, taskList, circleDataList } =
     DailyDetailPageParams();
   return (
     <Stack direction="row" height="100%" spacing={1} mx={2} pb={2}>
@@ -21,7 +21,7 @@ export default function DailyDetailPage() {
         {/** タスク */}
         <Stack height="390px">
           <TaskList
-            taskList={[]} //TODO:はやめに修正
+            taskList={taskList}
             isLoading={isLoading}
             navigateTaskPage={() => {}} // TODO:ナビゲーション関連つくるとき
             navigateCategoryPage={() => {}} // TODO:ナビゲーション関連つくるとき

--- a/my-app/src/type/Date.ts
+++ b/my-app/src/type/Date.ts
@@ -1,6 +1,6 @@
 import { CategoryWithPercentage } from "./Category";
 import { MemoDailyTask, MemoSummary, MemoTitleList } from "./Memo";
-import { TaskWithPercentage } from "./Task";
+import { DailyDetailTaskTableType, TaskWithPercentage } from "./Task";
 
 /** 日付の一覧データ型 */
 export type DateSummary = {
@@ -36,10 +36,8 @@ export type DateDetailPage = {
   id: number;
   /** 日付 */
   date: Date;
-  /** 稼働時間 */
-  dailyHours: number;
-  /** 割合つきのカテゴリリスト */
-  categoryList: CategoryWithPercentage[];
+  /** タスクの一覧 */
+  taskList: DailyDetailTaskTableType[];
   /** メモのタイトルと本文の一部と関連するタスクのリスト */
   memoList: MemoDailyTask[];
 };


### PR DESCRIPTION
わけるべきだったようなそうでもないような

# 変更点
- 日付詳細ページの型定義を変更
- 型定義変更に伴う詳細ページのデータ変換を追加

# 詳細
- 型定義変更
  - タスクについて日付のデータごとのデータに変更
  - タスクごとの時間と日当たりのタスクの個別idを取得可能
- 型定義に伴うデータ変更
  - 変換の関数を調整して変更(渡されるデータ型は元と一緒)
- 型定義を足したことによって、TaskListが表示可能に