### PR TITLE
feature:メモの詳細ダイアログ

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialog.stories.tsx
@@ -4,7 +4,13 @@ import MemoDetailDialog from "./MemoDetailDialog";
 
 const meta = {
   component: MemoDetailDialog,
-  args: { open: true, onClose: () => {} },
+  args: {
+    id: 1,
+    title: "タイトル",
+    taskName: "タスク1",
+    open: true,
+    onClose: () => {},
+  },
 } satisfies Meta<typeof MemoDetailDialog>;
 
 export default meta;

--- a/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  CircularProgress,
   Dialog,
   IconButton,
   Stack,
@@ -8,8 +9,18 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditNoteIcon from "@mui/icons-material/EditNote";
 import SaveIcon from "@mui/icons-material/Save";
+import MemoDetailDialogLogic from "./MemoDetailDialogLogic";
+import { Controller } from "react-hook-form";
+import ConfirmDeleteDialog from "@/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog";
+import useDialog from "@/hook/useDialog";
 
 type Props = {
+  /** メモid */
+  id: number;
+  /** メモタイトル */
+  title: string;
+  /** タスク名 */
+  taskName: string;
   /** ダイアログ開閉状態 */
   open: boolean;
   /** ダイアログを閉じる関数 */
@@ -19,50 +30,103 @@ type Props = {
 /**
  * メモの詳細を表示するダイアログ
  */
-export default function MemoDetailDialog({ open, onClose }: Props) {
-  const isEdit = true;
+export default function MemoDetailDialog({
+  id,
+  title,
+  taskName,
+  open,
+  onClose,
+}: Props) {
+  const {
+    isEdit,
+    control,
+    isLoading,
+    isSending,
+    handleEdit,
+    handleDelete,
+    onSubmit,
+  } = MemoDetailDialogLogic({
+    id,
+    onClose,
+  });
+  const {
+    open: openDelete,
+    onClose: onCloseDelete,
+    onOpen: onOpenDelete,
+  } = useDialog();
   return (
-    <Dialog
-      open={open}
-      onClose={
-        onClose // TODO:編集中は閉じないみたいな感じにしたい？またはそのまま保存させるか？
-      }
-      fullWidth
-    >
-      {/** 全体 */}
-      <Stack spacing={1} px={2} py={2}>
-        {/** ヘッダー部分 */}
-        <Stack direction="row" justifyContent={"space-between"}>
-          {/** タイトル情報 */}
-          <Stack spacing={1} maxWidth="450px" pl={1}>
-            <Typography overflow="hidden" textOverflow={"ellipsis"} noWrap>
-              タイトル：(メモのタイトル)
-            </Typography>
-            <Typography overflow="hidden" textOverflow={"ellipsis"} noWrap>
-              タスク名：(タスク名)
-            </Typography>
-          </Stack>
-          {/** アイコンボタン */}
-          <Stack direction="row" spacing={2} pr={3}>
-            <IconButton color="error">
-              <DeleteIcon />
-            </IconButton>
-            {/** 編集中かどうかで保存/編集ボタンを切り替え */}
-            {isEdit && (
-              <IconButton color="primary">
-                <SaveIcon />
-              </IconButton>
+    <>
+      <Dialog open={open} onClose={isEdit ? () => {} : onClose} fullWidth>
+        {/** 全体 */}
+        <Stack spacing={1} px={2} py={2}>
+          {/** ヘッダー部分 */}
+          <form onSubmit={onSubmit}>
+            <Stack direction="row" justifyContent={"space-between"}>
+              {/** タイトル情報 */}
+              <Stack spacing={1} maxWidth="450px" pl={1}>
+                <Typography overflow="hidden" textOverflow={"ellipsis"} noWrap>
+                  タイトル：{title}
+                </Typography>
+                <Typography overflow="hidden" textOverflow={"ellipsis"} noWrap>
+                  タスク名：{taskName}
+                </Typography>
+              </Stack>
+              {/** アイコンボタン */}
+              <Stack direction="row" spacing={2} pr={3}>
+                <IconButton onClick={onOpenDelete} color="error">
+                  <DeleteIcon />
+                </IconButton>
+                {/** 編集中かどうかで保存/編集ボタンを切り替え */}
+                {isEdit && (
+                  <IconButton type="submit" color="primary" loading={isSending}>
+                    <SaveIcon />
+                  </IconButton>
+                )}
+                {!isEdit && (
+                  <IconButton
+                    disabled={isLoading}
+                    onClick={handleEdit}
+                    color="primary"
+                  >
+                    <EditNoteIcon />
+                  </IconButton>
+                )}
+              </Stack>
+            </Stack>
+            {/** 本文の部分 */}
+            {isLoading && (
+              <Stack
+                height="150px"
+                alignItems={"center"}
+                justifyContent={"center"}
+              >
+                <CircularProgress />
+              </Stack>
             )}
-            {!isEdit && (
-              <IconButton color="primary">
-                <EditNoteIcon />
-              </IconButton>
+            {!isLoading && (
+              <Controller
+                name="text"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    fullWidth
+                    disabled={!isEdit}
+                    multiline
+                    rows={5}
+                    label="本文"
+                  />
+                )}
+              />
             )}
-          </Stack>
+          </form>
         </Stack>
-        {/** 本文の部分 */}
-        <TextField disabled={!isEdit} multiline rows={5} label="本文" />
-      </Stack>
-    </Dialog>
+      </Dialog>
+      <ConfirmDeleteDialog
+        open={openDelete}
+        onClose={onCloseDelete}
+        onAccept={handleDelete}
+      />
+    </>
   );
 }

--- a/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialogLogic.ts
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/dialog/MemoDetailDialogLogic.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+type SubmitData = {
+  /** 本文 */
+  text: string;
+};
+
+type Props = {
+  /** メモのid */
+  id: number;
+  /** ダイアログを閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * メモの詳細を表示するダイアログのロジック
+ */
+export default function MemoDetailDialogLogic({ id, onClose }: Props) {
+  // TODO:idを使ってデータフェッチ
+  const text =
+    "本文の文章をなんかかいて、それがまとめて渡されるあああ、えええ、っっっでええあえふぁ";
+  const isLoading = id ? false : true;
+
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [isSending, setIsSending] = useState<boolean>(false);
+  // RHF
+  const { control, handleSubmit, setValue } = useForm<SubmitData>({
+    defaultValues: { text: "" },
+  });
+  // ロード完了時にsetValueで初期値をセットする
+  useEffect(() => {
+    if (!isLoading) {
+      setValue("text", text);
+    }
+  }, [isLoading, setValue]);
+
+  const onSubmit = useCallback(
+    async (data: SubmitData) => {
+      //TODO:データ送信処理
+      setIsSending(true);
+      console.log("そうしんでーた", data);
+      console.log("送信先id", id);
+      if (true) {
+        // TODO: データのレスポンスに応じて分岐
+        setIsSending(false);
+        setIsEdit(false);
+      }
+    },
+    [id]
+  );
+
+  const handleDelete = useCallback(async () => {
+    // TODO: 削除のリクエスト
+    console.log("削除対象のid", id);
+    onClose();
+  }, [id, onClose]);
+
+  const handleEdit = useCallback(() => setIsEdit(true), []);
+  return {
+    /** 編集状態かどうか */
+    isEdit,
+    /** RHFのコントロールオブジェクト(MUIコンポーネント管理に使用) */
+    control,
+    /** ロード状態 */
+    isLoading,
+    /** 送信の状態 */
+    isSending,
+    /** 送信時のハンドラー */
+    onSubmit: handleSubmit(onSubmit),
+    /** 編集状態に入るときのハンドラー */
+    handleEdit,
+    /** 削除時のハンドラー */
+    handleDelete,
+  };
+}


### PR DESCRIPTION
たいとるどおり

# 詳細
- 編集/閲覧をisEditで切り替え
  - 編集：textfieldがenable
  - 閲覧:disabled
- textfieldの値はRHFで扱う
  - 非制御なのでコスト安
  - バリデーションは特になし
- 本文に関してはここで入手予定
  - 本文のフォームデフォ値は空白 => データフェッチ後にuseEffectでsetValueを呼び出してセットさせる
  - isLoading(データフェッチ完了時にだけ一度変わる),setValue(多分かわんない)を依存値にしてるので、一回しか走らないはず
  - データフェッチ何回もするならその度走ることになるけど、多分そっちのが都合よさそうだし問題なし
- 送信中のフラグを管理
  - 保存ボタンのloadingと連携(ユーザーにわかりやすい + 連続でクリックできないようにする)
- 本文データフェッチまでローディングインジケータ表示
  - 一応フェッチデータはフェッチ時(useEffect内)でしか使われないので、なくてもエラーはないはず
  - ただ、これ抜きだと急に本文出るみたいになるかもなので、まー挟んだ方がよさげ