### PR TITLE
だいあろぐ埋め込み

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/memo-list/table-body/CustomTableBody.tsx
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/table-body/CustomTableBody.tsx
@@ -1,5 +1,8 @@
 import { MemoDailyTask } from "@/type/Memo";
-import { TableRow, TableCell, Collapse, Box } from "@mui/material";
+import { TableRow, TableCell, Collapse, Box, IconButton } from "@mui/material";
+import AspectRatioIcon from "@mui/icons-material/AspectRatio";
+import useDialog from "@/hook/useDialog";
+import MemoDetailDialog from "../dialog/MemoDetailDialog";
 
 type Props = {
   /** メモ */
@@ -18,6 +21,7 @@ export default function CustomTableBody({
   isActive,
   onClickRow,
 }: Props) {
+  const { open, onClose, onOpen } = useDialog();
   return (
     <>
       <TableRow
@@ -44,14 +48,31 @@ export default function CustomTableBody({
         >
           {memoItem.task.name}
         </TableCell>
+        <TableCell>
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation(); // rowのイベント(文章の頭を展開する)を行わせない
+              onOpen();
+            }}
+          >
+            <AspectRatioIcon />
+          </IconButton>
+        </TableCell>
       </TableRow>
       <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={2}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={3}>
           <Collapse in={isActive} timeout="auto" unmountOnExit>
             <Box margin={1}>{memoItem.summary}</Box>
           </Collapse>
         </TableCell>
       </TableRow>
+      <MemoDetailDialog
+        id={memoItem.id}
+        title={memoItem.title}
+        taskName={memoItem.task.name}
+        open={open}
+        onClose={onClose}
+      />
     </>
   );
 }

--- a/my-app/src/pages/work-log/daily/:id/memo-list/table-header/CustomTableHeader.tsx
+++ b/my-app/src/pages/work-log/daily/:id/memo-list/table-header/CustomTableHeader.tsx
@@ -29,7 +29,7 @@ export default function CustomTableHeader({
     <>
       <TableHead>
         <TableRow>
-          <TableCell width="60%">
+          <TableCell width="50%">
             <CustomHeaderSortLabel
               title={"タイトル"}
               isSelected={isSelected("タイトル")}
@@ -37,7 +37,7 @@ export default function CustomTableHeader({
               onClickTitle={onClickTitle}
             />
           </TableCell>
-          <TableCell width="40%">
+          <TableCell width="35%">
             <CustomHeaderSortCheckLabel
               title={"タスク名"}
               isSelected={isSelected("タスク名")}
@@ -48,6 +48,7 @@ export default function CustomTableHeader({
               onLeaveTitle={onLeaveHoverTitle}
             />
           </TableCell>
+          <TableCell width="15%">{/** ボタン用の空白 */}</TableCell>
         </TableRow>
       </TableHead>
     </>


### PR DESCRIPTION
# 変更点
- メモリストのrowに詳細表示(および編集可能な)ダイアログを展開できるボタンを追加

# 詳細
- ヘッダー部分に空の列(全体の15%)を追加
  - 各行のボタン分のスペースを確保するため
- ボディの列を1列追加
  - IconButtonで展開ボタンを配置
  -  e.stopPropagation()でrowのイベント(行を展開する)を阻止
  - Collaspeの展開行のcolspanを2 =>3に変更(列追加に伴い)
- ボディの列にダイアログを追加
  - idとか受け取るのに都合がよかったので