### PR TITLE
feature:メモ追加時にタスク一覧を現在のタスク一覧から取得できるように変更

### DIFF
--- a/my-app/src/pages/work-log/daily/:id/menu/DailyDetailMenu.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/DailyDetailMenu.stories.tsx
@@ -7,6 +7,13 @@ const meta = {
   args: {
     date: new Date(),
     dailyHours: 8,
+    taskList: [
+      { id: 1, name: "タスク1" },
+      { id: 2, name: "タスク2" },
+      { id: 3, name: "タスク3" },
+      { id: 4, name: "タスク4" },
+      { id: 5, name: "タスク5" },
+    ],
   },
 } satisfies Meta<typeof DailyDetailMenu>;
 

--- a/my-app/src/pages/work-log/daily/:id/menu/DailyDetailMenu.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/DailyDetailMenu.tsx
@@ -5,18 +5,21 @@ import useDialog from "@/hook/useDialog";
 import TaskAddDialog from "./dialog/TaskAddDialog/TaskAddDialog";
 import MemoAddDialog from "./dialog/MemoAddDialog/MemoAddDialog";
 import DailyDetailMenuLogic from "./DailyDetailMenuLogic";
+import { TaskOption } from "@/type/Task";
 
 type Props = {
   /** 対象の日付データ */
   date: Date;
   /** 稼働時間 */
   dailyHours: number;
+  /** タスクの一覧(メモで使う) */
+  taskList: TaskOption[];
 };
 
 /**
  * 日付詳細　ナビゲーションやらのメニューのコンポーネント
  */
-export default function DailyDetailMenu({ date, dailyHours }: Props) {
+export default function DailyDetailMenu({ date, dailyHours, taskList }: Props) {
   const {
     open: openTask,
     onClose: onCloseTask,
@@ -90,6 +93,7 @@ export default function DailyDetailMenu({ date, dailyHours }: Props) {
       {openTask && <TaskAddDialog open={openTask} onClose={onCloseTask} />}
       {openMemo && (
         <MemoAddDialog
+          taskList={taskList}
           open={openMemo}
           onClose={onCloseMemo}
           isTaskSelected={false}

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.stories.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.stories.tsx
@@ -5,6 +5,13 @@ import MemoAddDialog from "./MemoAddDialog";
 const meta = {
   component: MemoAddDialog,
   args: {
+    taskList: [
+      { id: 1, name: "タスク1" },
+      { id: 2, name: "タスク2" },
+      { id: 3, name: "タスク3" },
+      { id: 4, name: "タスク4" },
+      { id: 5, name: "タスク5" },
+    ],
     open: true,
     onClose: () => {},
     isTaskSelected: false,

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
@@ -13,8 +13,11 @@ import {
 import NoteAddIcon from "@mui/icons-material/NoteAdd";
 import MemoAddDialogLogic from "./MemoAddDialogLogic";
 import { Controller } from "react-hook-form";
+import { TaskOption } from "@/type/Task";
 
 type Props = {
+  /** タスクの一覧 */
+  taskList: TaskOption[];
   /** ダイアログ開閉状態 */
   open: boolean;
   /** タスクを指定しているかどうか */
@@ -27,12 +30,14 @@ type Props = {
  * 日付詳細 メモを追加するためのダイアログ
  */
 export default function MemoAddDialog({
+  taskList,
   open,
   isTaskSelected,
   onClose,
 }: Props) {
-  const { taskList, tagList, onSubmit, control, isValid } = MemoAddDialogLogic({
+  const { tagList, onSubmit, control, isValid } = MemoAddDialogLogic({
     onClose,
+    taskList,
   });
   return (
     <Dialog open={open} onClose={onClose} fullWidth>

--- a/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialogLogic.tsx
+++ b/my-app/src/pages/work-log/daily/:id/menu/dialog/MemoAddDialog/MemoAddDialogLogic.tsx
@@ -15,21 +15,17 @@ type SubmitData = {
 };
 
 type Props = {
+  /** タスクの一覧 */
+  taskList: TaskOption[];
   /** ダイアログを閉じる関数 */
   onClose: () => void;
 };
 /**
  * メモ追加ダイアログコンポーネントのロジック
  */
-export default function MemoAddDialogLogic({ onClose }: Props) {
+export default function MemoAddDialogLogic({ taskList, onClose }: Props) {
   // TODO:でーたふぇっちする
-  const taskList: TaskOption[] = [
-    { id: 1, name: "タスク1" },
-    { id: 2, name: "タスク2" },
-    { id: 3, name: "タスク3" },
-    { id: 4, name: "タスク4" },
-    { id: 5, name: "タスク5" },
-  ];
+
   const tagList: TagOption[] = [
     { id: 0, name: "なし" },
     { id: 1, name: "タグ1" },

--- a/my-app/src/pages/work-log/daily/:id/page.tsx
+++ b/my-app/src/pages/work-log/daily/:id/page.tsx
@@ -9,8 +9,15 @@ import DailyDetailPageNavLogic from "./navLogic";
  * 日付詳細ページ
  */
 export default function DailyDetailPage() {
-  const { isLoading, date, dailyHours, memoList, taskList, circleDataList } =
-    DailyDetailPageParams();
+  const {
+    isLoading,
+    date,
+    dailyHours,
+    memoList,
+    taskList,
+    taskOptions,
+    circleDataList,
+  } = DailyDetailPageParams();
   const { navigateToCategoryDetail, navigateToTaskDetail } =
     DailyDetailPageNavLogic();
   return (
@@ -19,7 +26,11 @@ export default function DailyDetailPage() {
       <Stack width="50%" spacing={1}>
         {/** メニュー */}
         <Stack height="188px" pt={7} width="85%">
-          <DailyDetailMenu date={date} dailyHours={dailyHours} />
+          <DailyDetailMenu
+            date={date}
+            dailyHours={dailyHours}
+            taskList={taskOptions}
+          />
         </Stack>
         {/** タスク */}
         <Stack height="390px">

--- a/my-app/src/pages/work-log/daily/:id/param.ts
+++ b/my-app/src/pages/work-log/daily/:id/param.ts
@@ -1,5 +1,5 @@
 import { DailyCategoryCircleGraph, DateDetailPage } from "@/type/Date";
-import { DailyDetailTaskTableType } from "@/type/Task";
+import { DailyDetailTaskTableType, TaskOption } from "@/type/Task";
 import { useMemo } from "react";
 
 /**
@@ -90,6 +90,11 @@ export default function DailyDetailPageParams() {
     [params.taskList]
   );
   const taskList = params.taskList;
+  const taskOptions = taskList.reduce<TaskOption[]>((a, b) => {
+    const taskData: TaskOption = { id: b.task.id, name: b.task.name };
+    a.push(taskData);
+    return a;
+  }, []);
   const memoList = params.memoList;
   const circleDataList: DailyCategoryCircleGraph[] = useMemo(() => {
     const data = params.taskList;
@@ -146,6 +151,8 @@ export default function DailyDetailPageParams() {
     dailyHours,
     /** タスク一覧 */
     taskList,
+    /** タスク一覧(タイトルのみ) */
+    taskOptions,
     /** メモ一覧 */
     memoList,
     /** 円グラフのデータ */


### PR DESCRIPTION
# 詳細
- めぬーのメモを追加時の選べるタスクについて
## 元々
- 全部のタスクを入手できるように(あるいは、現在のタスク)
  - つまり、ここでフェッチする前提
## 修正後
- 親から渡される
  - 親がフェッチしたデータから取得できる
  - この分コストが浮く

## その他の影響
- 受け渡し元にもparam追加
  - MemoAddDialog > Menu > page
  - 手前二つは受け渡しのみ
  - pageは生データを変換して受け渡し