### PR TITLE
feature:タスク一覧ページテーブルボディのロジックを追記(コンポーネントには未適応)

### DIFF
--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
@@ -1,6 +1,14 @@
 import { TaskSummary } from "@/type/Task";
 import { format } from "date-fns";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { useForm } from "react-hook-form";
+
+type SubmitData = {
+  /** お気に入りのチェック */
+  isFavorite: boolean;
+  /** 進捗率 */
+  progress: number;
+};
 
 type Props = {
   /** タスクの一覧データ */
@@ -11,6 +19,7 @@ type Props = {
  * タスク一覧ページのテーブルボディコンポーネントのロジック部分
  */
 export default function TaskSummaryTableBodyLogic({ taskItem }: Props) {
+  // メモ化
   const startDateString = useMemo(
     () => format(taskItem.startDate, "yyyy/MM/dd"),
     [taskItem.startDate]
@@ -19,10 +28,26 @@ export default function TaskSummaryTableBodyLogic({ taskItem }: Props) {
     () => format(taskItem.lastDate, "yyyy/MM/dd"),
     [taskItem.lastDate]
   );
-
   const progressSelects = useMemo(() => {
     return Array.from({ length: 11 }, (_, i) => i * 10);
   }, []);
+
+  // RHF
+  const {
+    control,
+    getValues,
+    formState: { isDirty },
+  } = useForm<SubmitData>({
+    defaultValues: {
+      isFavorite: taskItem.isFavorite,
+      progress: taskItem.progress,
+    },
+  });
+
+  const getData = useCallback(
+    () => (isDirty ? getValues() : null),
+    [getValues, isDirty]
+  );
 
   return {
     /** 開始日のstring */
@@ -31,5 +56,11 @@ export default function TaskSummaryTableBodyLogic({ taskItem }: Props) {
     lastDateString,
     /** 進捗の選択賜 */
     progressSelects,
+    /** RHFのコントロールオブジェクト(MUIコンポーネントに必須) */
+    control,
+    /** フォームの変更の有無 */
+    isDirty,
+    /** フォームのデータを取得する関数(isDirty=falseの場合はnullを返す) */
+    getData,
   };
 }


### PR DESCRIPTION
# 変更点
- Logicファイルにロジックを追記

# 詳細
- RHF関連のロジックを追記
  - フォーム値を設定
    - お気に入り：isFavorite 進捗：progressとして命名
    - 初期値はtaskItemからそのままもらう
  - formstate
    - isDirtyのみ(変更があった場合のみ送信させるようにする)
  - getValues
    - 親でフォームの値を読み取ってもらうのに使う
    - こっちで管理する都合でhandleSubmitは不要