### PR TITLE
Feature/update task summary table body

### DIFF
--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
@@ -22,14 +22,19 @@ type Props = {
  * タスク一覧ページのテーブルボディコンポーネント
  */
 export default function TaskSummaryTableBody({ taskItem }: Props) {
-  const { startDateString, lastDateString, progressSelects, control, isDirty } =
-    TaskSummaryTableBodyLogic({
-      taskItem,
-    });
+  const {
+    startDateString,
+    lastDateString,
+    progressSelects,
+    backGroundColor,
+    control,
+  } = TaskSummaryTableBodyLogic({
+    taskItem,
+  });
   return (
     <form>
-      <TableRow>
-        {/** おきにいり(チェックボックス) TODO:RHFでコントロールさせる */}
+      <TableRow sx={{ backgroundColor: backGroundColor }}>
+        {/** おきにいり(チェックボックス) */}
         <TableCell>
           <Controller
             name="isFavorite"
@@ -47,7 +52,7 @@ export default function TaskSummaryTableBody({ taskItem }: Props) {
         <TableCell>{taskItem.taskName}</TableCell>
         {/** カテゴリ名(固定) */}
         <TableCell>{taskItem.categoryName}</TableCell>
-        {/** 進捗{セレクト} TODO:RHFでコントロールさせる */}
+        {/** 進捗{セレクト} */}
         <TableCell>
           <FormControl fullWidth>
             <InputLabel>進捗</InputLabel>

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
@@ -49,6 +49,11 @@ export default function TaskSummaryTableBodyLogic({ taskItem }: Props) {
     [getValues, isDirty]
   );
 
+  const backGroundColor = useMemo(
+    () => (isDirty ? "rgb(255, 238, 238)" : "rgb(255, 255, 255)"),
+    [isDirty]
+  );
+
   return {
     /** 開始日のstring */
     startDateString,
@@ -56,6 +61,8 @@ export default function TaskSummaryTableBodyLogic({ taskItem }: Props) {
     lastDateString,
     /** 進捗の選択賜 */
     progressSelects,
+    /** 背景色(isDirtyの値で分岐) */
+    backGroundColor,
     /** RHFのコントロールオブジェクト(MUIコンポーネントに必須) */
     control,
     /** フォームの変更の有無 */


### PR DESCRIPTION
元ロジックは #107 なので、そっちが先

# 変更点
- RHFで各フォームを管理下にする
- 値を変更時のuiを調整

# 詳細
- ControllerでisFavorite,progressのフォームを囲み
  - これでRHFで値を管理可能
- isDirtyで分岐する背景色を設定
  - useMemoでメモ化して渡す
  - isDirtyならちょい赤っぽい背景で強調させる