### PR TITLE
refactor:一覧ページのデータをダミーデータに昇格

### DIFF
--- a/my-app/src/dummy/task-page.ts
+++ b/my-app/src/dummy/task-page.ts
@@ -1,0 +1,55 @@
+import { TaskSummary } from "@/type/Task";
+
+/** 一覧ページのダミーデータ */
+export const DUMMY_TASK_SUMMARY_DATA: TaskSummary[] = [
+  {
+    id: 1,
+    isFavorite: false,
+    taskName: "タスク1",
+    categoryName: "カテゴリ1",
+    progress: 50,
+    totalHours: 20,
+    startDate: new Date("2025-03-24"),
+    lastDate: new Date("2025-04-10"),
+  },
+  {
+    id: 2,
+    isFavorite: false,
+    taskName: "タスク2",
+    categoryName: "カテゴリ1",
+    progress: 40,
+    totalHours: 25,
+    startDate: new Date("2025-03-25"),
+    lastDate: new Date("2025-04-12"),
+  },
+  {
+    id: 3,
+    isFavorite: false,
+    taskName: "タスク3",
+    categoryName: "カテゴリ2",
+    progress: 50,
+    totalHours: 20,
+    startDate: new Date("2025-02-22"),
+    lastDate: new Date("2025-03-14"),
+  },
+  {
+    id: 4,
+    isFavorite: false,
+    taskName: "タスク4",
+    categoryName: "カテゴリ2",
+    progress: 100,
+    totalHours: 20,
+    startDate: new Date("2025-01-14"),
+    lastDate: new Date("2025-02-05"),
+  },
+  {
+    id: 5,
+    isFavorite: true,
+    taskName: "タスク5",
+    categoryName: "カテゴリ3",
+    progress: 100,
+    totalHours: 12,
+    startDate: new Date("2025-04-10"),
+    lastDate: new Date("2025-04-11"),
+  },
+];

--- a/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
+++ b/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
@@ -1,62 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import TaskSummaryTable from "./TaskSummaryTable";
+import { DUMMY_TASK_SUMMARY_DATA } from "@/dummy/task-page";
 
 const meta = {
   component: TaskSummaryTable,
   args: {
-    taskList: [
-      {
-        id: 1,
-        isFavorite: false,
-        taskName: "タスク1",
-        categoryName: "カテゴリ1",
-        progress: 50,
-        totalHours: 20,
-        startDate: new Date("2025-03-24"),
-        lastDate: new Date("2025-04-10"),
-      },
-      {
-        id: 2,
-        isFavorite: false,
-        taskName: "タスク2",
-        categoryName: "カテゴリ1",
-        progress: 40,
-        totalHours: 25,
-        startDate: new Date("2025-03-25"),
-        lastDate: new Date("2025-04-12"),
-      },
-      {
-        id: 3,
-        isFavorite: false,
-        taskName: "タスク3",
-        categoryName: "カテゴリ2",
-        progress: 50,
-        totalHours: 20,
-        startDate: new Date("2025-02-22"),
-        lastDate: new Date("2025-03-14"),
-      },
-      {
-        id: 4,
-        isFavorite: false,
-        taskName: "タスク4",
-        categoryName: "カテゴリ2",
-        progress: 100,
-        totalHours: 20,
-        startDate: new Date("2025-01-14"),
-        lastDate: new Date("2025-02-05"),
-      },
-      {
-        id: 5,
-        isFavorite: true,
-        taskName: "タスク5",
-        categoryName: "カテゴリ3",
-        progress: 100,
-        totalHours: 12,
-        startDate: new Date("2025-04-10"),
-        lastDate: new Date("2025-04-11"),
-      },
-    ],
+    taskList: DUMMY_TASK_SUMMARY_DATA,
   },
 } satisfies Meta<typeof TaskSummaryTable>;
 


### PR DESCRIPTION
# 詳細
- TaskSummaryTableのstorybook上で使用していたデータをdummyファイルとして分離
  - データフェッチ実装までTaskSummaryPageのダミーデータとして利用するため