### PR TITLE
feature:タスク一覧ページで各行のデータの保存/破棄のメソッド

### DIFF
--- a/my-app/src/pages/work-log/task/page.tsx
+++ b/my-app/src/pages/work-log/task/page.tsx
@@ -6,20 +6,28 @@ import TaskSummaryTable from "./table/TaskSummaryTable";
  * タスク一覧ページ
  */
 export default function TaskSummaryPage() {
-  const { taskSummaryData, isLoading, onDirtyChange, isDirty } =
-    TaskSummaryPageParams();
+  const {
+    taskSummaryData,
+    isLoading,
+    rowRefs,
+    handleSaveAll,
+    handleResetAll,
+    onDirtyChange,
+    isDirty,
+  } = TaskSummaryPageParams();
   return (
     <>
       <TaskSummaryHeader
         isDirty={isDirty}
         isSelected={false}
-        onClickSave={() => {}}
-        onClickReset={() => {}}
+        onClickSave={handleSaveAll}
+        onClickReset={handleResetAll}
         onClickNavigateDetail={() => {}}
       />
       {!isLoading && (
         <TaskSummaryTable
           taskList={taskSummaryData}
+          ref={rowRefs.current}
           onDirtyChange={onDirtyChange}
         />
       )}

--- a/my-app/src/pages/work-log/task/params.ts
+++ b/my-app/src/pages/work-log/task/params.ts
@@ -1,5 +1,13 @@
 import { DUMMY_TASK_SUMMARY_DATA } from "@/dummy/task-page";
-import { useCallback, useMemo, useState } from "react";
+import {
+  createRef,
+  RefObject,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { TaskSummaryTableBodyHandle } from "./table/body/TaskSummaryTableBodyLogic";
 
 /**
  * タスク一覧ページのパラメータ関連
@@ -22,14 +30,62 @@ export default function TaskSummaryPageParams() {
   );
   console.log(isDirtyRecord);
 
+  const initialRef = taskSummaryData.reduce<
+    Record<number, RefObject<TaskSummaryTableBodyHandle | null>>
+  >((a, b) => {
+    const key = b.id;
+    const value = createRef<TaskSummaryTableBodyHandle>();
+    return { ...a, [key]: value };
+  }, {});
+  // 各行の参照(key:タスクのid,value:各行のメソッド(saveとreset用))
+  const rowRefs =
+    useRef<Record<number, RefObject<TaskSummaryTableBodyHandle | null>>>(
+      initialRef
+    );
+
+  // 変更のある対象のキーを取得する関数
+  const getTargetKeys = useCallback(() => {
+    const keys = Object.keys(rowRefs.current);
+    const filtered = keys.filter((key) => isDirtyRecord[Number(key)] === true);
+    return filtered;
+  }, [isDirtyRecord]);
+
+  const handleSaveAll = useCallback(async () => {
+    const result = [];
+    const targetKeys = getTargetKeys(); // 変更のあるキーのみを取得
+    // 更新データを取得
+    for (const key of targetKeys) {
+      const ref = rowRefs.current[Number(key)];
+      const data = ref.current?.getFormData();
+      result.push({ id: Number(key), ...data }); // 判別ようにidを付与
+    }
+    // TODO:ここでデータ送信
+    console.log("送信データ", result);
+    // TODO:この後にデータフェッチ => await => フォームresetで更新後の値を適応させる
+  }, [getTargetKeys]);
+
+  const handleResetAll = useCallback(() => {
+    const targetKeys = getTargetKeys();
+    for (const key of targetKeys) {
+      const ref = rowRefs.current[Number(key)];
+      ref.current?.resetFormData(); // ここで初期化
+    }
+  }, [getTargetKeys]);
+
   return {
     /** タスク一覧 */
     taskSummaryData,
     /** ロード状態 */
     isLoading,
+    /** 各行のref値(各行のメソッドを呼び出すのに必要) */
+    rowRefs,
     /** dirty状態を切り替える関数(各行について切り替え) */
     onDirtyChange,
     /** dirtyかどうか(全ての行がdirtyでない場合のみfalse) */
     isDirty,
+    /** まとめてセーブを行う関数 */
+    handleSaveAll,
+    /** まとめてリセットを行う関数 */
+    handleResetAll,
   };
 }

--- a/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
+++ b/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   component: TaskSummaryTable,
   args: {
     taskList: DUMMY_TASK_SUMMARY_DATA,
+    ref: {},
     onDirtyChange: () => {},
   },
 } satisfies Meta<typeof TaskSummaryTable>;

--- a/my-app/src/pages/work-log/task/table/TaskSummaryTable.tsx
+++ b/my-app/src/pages/work-log/task/table/TaskSummaryTable.tsx
@@ -3,10 +3,14 @@ import { Table, TableBody, TableContainer, TableHead } from "@mui/material";
 import TaskSummaryTableHeader from "./header/TaskSummaryTableHeader";
 import TaskSummaryTableBody from "./body/TaskSummaryTableBody";
 import TaskSummaryTableLogic from "./TaskSummaryTableLogic";
+import { RefObject } from "react";
+import { TaskSummaryTableBodyHandle } from "./body/TaskSummaryTableBodyLogic";
 
 type Props = {
   /** タスク一覧データ */
   taskList: TaskSummary[];
+  /** ref値(親で関数を使えるように) */
+  ref: Record<number, RefObject<TaskSummaryTableBodyHandle | null>>;
   /** isDirtyの変化の通知を受け取る関数 */
   onDirtyChange: (targetId: number, isDirty: boolean) => void;
 };
@@ -14,7 +18,11 @@ type Props = {
 /**
  * タスク一覧ページのテーブル
  */
-export default function TaskSummaryTable({ taskList, onDirtyChange }: Props) {
+export default function TaskSummaryTable({
+  taskList,
+  ref,
+  onDirtyChange,
+}: Props) {
   const {
     isAsc,
     categoryFilterList,
@@ -48,6 +56,7 @@ export default function TaskSummaryTable({ taskList, onDirtyChange }: Props) {
               <TaskSummaryTableBody
                 key={taskItem.id}
                 taskItem={taskItem}
+                ref={ref[taskItem.id]}
                 onDirtyChange={onDirtyChange}
               />
             ))}

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.stories.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import TaskSummaryTableBody from "./TaskSummaryTableBody";
+import { TaskSummaryTableBodyHandle } from "./TaskSummaryTableBodyLogic";
+import { useRef } from "react";
 
 const meta = {
   component: TaskSummaryTableBody,
@@ -21,9 +23,15 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof TaskSummaryTableBody>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: function Render(args) {
+    const rowRef = useRef<TaskSummaryTableBodyHandle>(null);
+
+    return <TaskSummaryTableBody {...args} ref={rowRef} />;
+  },
+};
 export const Favorite: Story = {
   args: {
     taskItem: {
@@ -36,5 +44,10 @@ export const Favorite: Story = {
       startDate: new Date("2025-03-24"),
       lastDate: new Date("2025-04-10"),
     },
+  },
+  render: function Render(args) {
+    const rowRef = useRef<TaskSummaryTableBodyHandle>(null);
+
+    return <TaskSummaryTableBody {...args} ref={rowRef} />;
   },
 };

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
@@ -8,14 +8,19 @@ import {
   TableCell,
   TableRow,
 } from "@mui/material";
-import TaskSummaryTableBodyLogic from "./TaskSummaryTableBodyLogic";
+import TaskSummaryTableBodyLogic, {
+  TaskSummaryTableBodyHandle,
+} from "./TaskSummaryTableBodyLogic";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import StarIcon from "@mui/icons-material/Star";
 import { Controller } from "react-hook-form";
+import { Ref } from "react";
 
 type Props = {
   /** タスクの一覧データ */
   taskItem: TaskSummary;
+  /** ref値(親で関数を使えるように) */
+  ref: Ref<TaskSummaryTableBodyHandle | null>;
   /** isDirtyの変化の通知を受け取る関数 */
   onDirtyChange: (targetId: number, isDirty: boolean) => void;
 };
@@ -25,6 +30,7 @@ type Props = {
  */
 export default function TaskSummaryTableBody({
   taskItem,
+  ref,
   onDirtyChange,
 }: Props) {
   const {
@@ -35,6 +41,7 @@ export default function TaskSummaryTableBody({
     control,
   } = TaskSummaryTableBodyLogic({
     taskItem,
+    ref,
     onDirtyChange,
   });
   return (

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
@@ -1,6 +1,6 @@
 import { TaskSummary } from "@/type/Task";
 import { format } from "date-fns";
-import { useCallback, useEffect, useMemo } from "react";
+import { Ref, useEffect, useImperativeHandle, useMemo } from "react";
 import { useForm } from "react-hook-form";
 
 type SubmitData = {
@@ -10,9 +10,15 @@ type SubmitData = {
   progress: number;
 };
 
+export type TaskSummaryTableBodyHandle = {
+  getFormData: () => SubmitData;
+  resetFormData: () => void;
+};
 type Props = {
   /** タスクの一覧データ */
   taskItem: TaskSummary;
+  /** ref値(親で関数を使えるように) */
+  ref: Ref<TaskSummaryTableBodyHandle>;
   /** isDirtyの変化の通知を受け取る関数 */
   onDirtyChange: (targetId: number, isDirty: boolean) => void;
 };
@@ -22,6 +28,7 @@ type Props = {
  */
 export default function TaskSummaryTableBodyLogic({
   taskItem,
+  ref,
   onDirtyChange,
 }: Props) {
   // メモ化
@@ -41,6 +48,7 @@ export default function TaskSummaryTableBodyLogic({
   const {
     control,
     getValues,
+    reset,
     formState: { isDirty },
   } = useForm<SubmitData>({
     defaultValues: {
@@ -49,10 +57,11 @@ export default function TaskSummaryTableBodyLogic({
     },
   });
 
-  const getData = useCallback(
-    () => (isDirty ? getValues() : null),
-    [getValues, isDirty]
-  );
+  // 親に渡すメソッド
+  useImperativeHandle(ref, () => ({
+    getFormData: () => getValues(), // RHFのデータ取得
+    resetFormData: () => reset(), // RHFのデータを戻すメソッド
+  }));
 
   const backGroundColor = useMemo(
     () => (isDirty ? "rgb(255, 238, 238)" : "rgb(255, 255, 255)"),
@@ -78,7 +87,5 @@ export default function TaskSummaryTableBodyLogic({
     control,
     /** フォームの変更の有無 */
     isDirty,
-    /** フォームのデータを取得する関数(isDirty=falseの場合はnullを返す) */
-    getData,
   };
 }


### PR DESCRIPTION
# 変更点
- 各行の変更内容を送信するためのメソッドを実装
- 各行の変更内容を破棄するためのメソッドを実装

# 詳細
## 概要
- pageからrefをTableRowに渡す
- TableRowがrefにuseImperativeHandleを使ってメソッドを登録
- 親が各行のref値からメソッドを実行
- 返り値を整形してデータとして送信
## refについて
- 子から順番に
  - TaskSummaryTableBodyについて
    - useImperativeHandleを用いてrefにイベントを付与
    - ref値は上記のフックに従ってRef<[渡すハンドラーの型定義]>
  - TaskSummaryTable
    - propの受け渡し
    - Ref<T>とRefObject<T>は互換があるのと、RefObject<T>であればcurrentからメソッドを呼び出せるのでRefObject<T>でTableBodyには受け渡しする
    - idごとに識別したいので親からはRecord<number,RefObject<T>>で受け取る
    - 子にはrecord[id]でRefObject<T>を渡す
  - page
    - refで管理
    - useRef<Record<number,RefObject<T>>>で管理
    - ref.currentでTaskSummaryTableには受け渡し
    - 各keyには初期値をcreateRef<T>()で与える
      - これがないとuseImperativeHandleが受け取るrefがundefinedになってハンドラーが登録できなくなるため必須
## 関数について
- isDirtyRecordから変更のある行を取得
  - 互いにkeyにidを付与しているため同期可能
- 変更のある行の分forループを行って呼び出しを行う
  - saveの場合
    - 空のresult配列を作成して、フォームのデータ(isFavorite,progress)にidを付与してpushする
    - まとめてこれを送信(今んとこ型は詳しく決めてないけど、多分このままでいきそう)
  - resetの場合
    - reset関数を呼び出す(返り値は特に使用しないので、void)