### PR TITLE
ui:選択状態のprop受け渡しと選択時のuiなど

### DIFF
--- a/my-app/src/pages/work-log/task/page.tsx
+++ b/my-app/src/pages/work-log/task/page.tsx
@@ -28,6 +28,8 @@ export default function TaskSummaryPage() {
         <TaskSummaryTable
           taskList={taskSummaryData}
           ref={rowRefs.current}
+          selectedItemId={0} // TODO
+          onClickItemRow={() => {}} // TODO
           onDirtyChange={onDirtyChange}
         />
       )}

--- a/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
+++ b/my-app/src/pages/work-log/task/table/TaskSummaryTable.stories.tsx
@@ -8,6 +8,8 @@ const meta = {
   args: {
     taskList: DUMMY_TASK_SUMMARY_DATA,
     ref: {},
+    selectedItemId: 2,
+    onClickItemRow: () => {},
     onDirtyChange: () => {},
   },
 } satisfies Meta<typeof TaskSummaryTable>;

--- a/my-app/src/pages/work-log/task/table/TaskSummaryTable.tsx
+++ b/my-app/src/pages/work-log/task/table/TaskSummaryTable.tsx
@@ -9,6 +9,10 @@ import { TaskSummaryTableBodyHandle } from "./body/TaskSummaryTableBodyLogic";
 type Props = {
   /** タスク一覧データ */
   taskList: TaskSummary[];
+  /** 選択中のアイテムid */
+  selectedItemId: number | null;
+  /** アイテム行をクリックした際のハンドラー */
+  onClickItemRow: (id: number) => void;
   /** ref値(親で関数を使えるように) */
   ref: Record<number, RefObject<TaskSummaryTableBodyHandle | null>>;
   /** isDirtyの変化の通知を受け取る関数 */
@@ -20,6 +24,8 @@ type Props = {
  */
 export default function TaskSummaryTable({
   taskList,
+  selectedItemId,
+  onClickItemRow,
   ref,
   onDirtyChange,
 }: Props) {
@@ -57,6 +63,8 @@ export default function TaskSummaryTable({
                 key={taskItem.id}
                 taskItem={taskItem}
                 ref={ref[taskItem.id]}
+                isSelected={selectedItemId === taskItem.id}
+                onClickRow={onClickItemRow}
                 onDirtyChange={onDirtyChange}
               />
             ))}

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.stories.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.stories.tsx
@@ -18,6 +18,8 @@ const meta = {
       lastDate: new Date("2025-04-10"),
     },
     onDirtyChange: () => {},
+    isSelected: false,
+    onClickRow: () => {},
   },
 } satisfies Meta<typeof TaskSummaryTableBody>;
 
@@ -45,6 +47,14 @@ export const Favorite: Story = {
       lastDate: new Date("2025-04-10"),
     },
   },
+  render: function Render(args) {
+    const rowRef = useRef<TaskSummaryTableBodyHandle>(null);
+
+    return <TaskSummaryTableBody {...args} ref={rowRef} />;
+  },
+};
+export const Selected: Story = {
+  args: { isSelected: true },
   render: function Render(args) {
     const rowRef = useRef<TaskSummaryTableBodyHandle>(null);
 

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
@@ -19,8 +19,12 @@ import { Ref } from "react";
 type Props = {
   /** タスクの一覧データ */
   taskItem: TaskSummary;
+  /** 行の選択状態 */
+  isSelected: boolean;
   /** ref値(親で関数を使えるように) */
   ref: Ref<TaskSummaryTableBodyHandle | null>;
+  /** 行をクリックした際のハンドラー */
+  onClickRow: (rowId: number) => void;
   /** isDirtyの変化の通知を受け取る関数 */
   onDirtyChange: (targetId: number, isDirty: boolean) => void;
 };
@@ -30,7 +34,9 @@ type Props = {
  */
 export default function TaskSummaryTableBody({
   taskItem,
+  isSelected,
   ref,
+  onClickRow,
   onDirtyChange,
 }: Props) {
   const {
@@ -38,6 +44,7 @@ export default function TaskSummaryTableBody({
     lastDateString,
     progressSelects,
     backGroundColor,
+    backGroundColorHover,
     control,
   } = TaskSummaryTableBodyLogic({
     taskItem,
@@ -45,7 +52,17 @@ export default function TaskSummaryTableBody({
     onDirtyChange,
   });
   return (
-    <TableRow sx={{ backgroundColor: backGroundColor }}>
+    <TableRow
+      selected={isSelected}
+      onClick={() => onClickRow(taskItem.id)}
+      sx={{
+        backgroundColor: backGroundColor,
+        "&:hover": {
+          cursor: "pointer",
+          backgroundColor: backGroundColorHover,
+        },
+      }}
+    >
       {/** おきにいり(チェックボックス) */}
       <TableCell>
         <Controller

--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBodyLogic.ts
@@ -68,6 +68,11 @@ export default function TaskSummaryTableBodyLogic({
     [isDirty]
   );
 
+  const backGroundColorHover = useMemo(
+    () => (isDirty ? "rgb(255, 230, 230)" : "rgb(249, 252, 255)"),
+    [isDirty]
+  );
+
   // isDirtyが変わった際の通知(taskItem.idは固定/onDirtyChangeはcallbackであるため、isDirtyの値が変わった時だけ走る、予定)
   // (onDirtyChangeでset関数を使う場合はprevを必ず使うこと(レンダー時に再生成すると不都合なので))
   useEffect(() => {
@@ -83,6 +88,8 @@ export default function TaskSummaryTableBodyLogic({
     progressSelects,
     /** 背景色(isDirtyの値で分岐) */
     backGroundColor,
+    /** ホバー時の背景色(isDirtyの値で分岐) */
+    backGroundColorHover,
     /** RHFのコントロールオブジェクト(MUIコンポーネントに必須) */
     control,
     /** フォームの変更の有無 */


### PR DESCRIPTION
# 変更点
- 行の選択状態に関するpropを親から受け渡し
  - 親での実装はまだ
- 選択状態に関する行のuiを作成

# 詳細
- 行のuiについて
  - ホバー時
    - カーソルを変更してクリックできる感を出す
    - 背景を濃くしてクリックできる感を出す
  - 選択時
    - selectedプロパティを使って制御
    - このプロパティに備わってる選択時・ホバー時の動作をそのまま利用
- プロパティの受け渡しについて
  - 各行では選択しているかどうかと、クリック時のハンドラーを受け取る
  - テーブルでは選択しているアイテムの情報とクリック時のハンドラーを受け取る
  - pageではそれ自体の実装を行う予定
    - これはまだやってない(次回やる)