### PR TITLE
feature:選択状態のロジック

### DIFF
--- a/my-app/src/pages/work-log/task/page.tsx
+++ b/my-app/src/pages/work-log/task/page.tsx
@@ -14,12 +14,15 @@ export default function TaskSummaryPage() {
     handleResetAll,
     onDirtyChange,
     isDirty,
+    selectedItemId,
+    handleSelectItem,
+    isAnyItemSelected,
   } = TaskSummaryPageParams();
   return (
     <>
       <TaskSummaryHeader
         isDirty={isDirty}
-        isSelected={false}
+        isSelected={isAnyItemSelected}
         onClickSave={handleSaveAll}
         onClickReset={handleResetAll}
         onClickNavigateDetail={() => {}}
@@ -28,8 +31,8 @@ export default function TaskSummaryPage() {
         <TaskSummaryTable
           taskList={taskSummaryData}
           ref={rowRefs.current}
-          selectedItemId={0} // TODO
-          onClickItemRow={() => {}} // TODO
+          selectedItemId={selectedItemId}
+          onClickItemRow={handleSelectItem}
           onDirtyChange={onDirtyChange}
         />
       )}

--- a/my-app/src/pages/work-log/task/params.ts
+++ b/my-app/src/pages/work-log/task/params.ts
@@ -72,6 +72,18 @@ export default function TaskSummaryPageParams() {
     }
   }, [getTargetKeys]);
 
+  // 選択状態について
+  const [selectedItemId, setSelectedItemId] = useState<number | null>(null);
+  const handleSelectItem = useCallback((id: number) => {
+    setSelectedItemId((prev) => {
+      // 選択中のアイテムを再度クリックした場合は選択を解除(null)
+      if (prev === id) return null;
+      // 上記を除いた全ての場合洗濯中のアイテムにそのidを設定する
+      return id;
+    });
+  }, []);
+  const isAnyItemSelected = !!selectedItemId;
+
   return {
     /** タスク一覧 */
     taskSummaryData,
@@ -87,5 +99,11 @@ export default function TaskSummaryPageParams() {
     handleSaveAll,
     /** まとめてリセットを行う関数 */
     handleResetAll,
+    /** 選択中のアイテムid */
+    selectedItemId,
+    /** アイテム選択時のハンドラー */
+    handleSelectItem,
+    /** いずれかのアイテムが選択されているか */
+    isAnyItemSelected,
   };
 }


### PR DESCRIPTION
タイトル通り

# 詳細
- 選択中のアイテムのidについてuseStateで管理
- 選択中のアイテムをセットする関数をuseCallbackで管理
  - prevと比較して分岐
  - prevと新しいアイテムのidが一緒の場合=選択中のアイテムを再度クリックした場合は選択を解除するように
  - それ以外はアイテムをセットする
    - prevを用いることで依存関係をなくしてパフォーマンス効率up
  - ヘッダーでのアイテムの選択状態はselectedItemIdの有無で判別(nullの場合のみ非選択状態)