### PR TITLE
feature:お気に入りや進捗を変えた際にアイテムが選択状態にならないように変更

### DIFF
--- a/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
+++ b/my-app/src/pages/work-log/task/table/body/TaskSummaryTableBody.tsx
@@ -71,6 +71,7 @@ export default function TaskSummaryTableBody({
           render={({ field }) => (
             <Checkbox
               {...field}
+              onClick={(e) => e.stopPropagation()}
               checked={field.value} // 初期値のセットに明示する必要あり
               icon={<StarBorderIcon />}
               checkedIcon={<StarIcon />}
@@ -90,7 +91,11 @@ export default function TaskSummaryTableBody({
             name="progress"
             control={control}
             render={({ field }) => (
-              <Select {...field} label={"進捗"}>
+              <Select
+                {...field}
+                onClick={(e) => e.stopPropagation()}
+                label={"進捗"}
+              >
                 {progressSelects.map((v) => (
                   <MenuItem key={v} value={v}>
                     {v}%


### PR DESCRIPTION
タイトル通り

# 詳細
- onClickイベントに e.stopPropagation() を設定することでrowのイベントが伝播されないように変更
  - 進捗のSelectとお気に入りのCheckBoxにそれぞれ適応
  - 今のRHFの実装だとonClickは特に使用してないので問題はないはず
  - 今後使う機能によってはonClickイベントに追記する必要あるかも？
  - まーonChangeで関連することがほとんどだと思うので、片隅に置いとくくらいでよさそう