### PR TITLE
feature:ナビゲーションのロジック

### DIFF
--- a/my-app/src/pages/work-log/task/page.tsx
+++ b/my-app/src/pages/work-log/task/page.tsx
@@ -17,6 +17,7 @@ export default function TaskSummaryPage() {
     selectedItemId,
     handleSelectItem,
     isAnyItemSelected,
+    navigateToDetail,
   } = TaskSummaryPageParams();
   return (
     <>
@@ -25,7 +26,7 @@ export default function TaskSummaryPage() {
         isSelected={isAnyItemSelected}
         onClickSave={handleSaveAll}
         onClickReset={handleResetAll}
-        onClickNavigateDetail={() => {}}
+        onClickNavigateDetail={navigateToDetail}
       />
       {!isLoading && (
         <TaskSummaryTable

--- a/my-app/src/pages/work-log/task/params.ts
+++ b/my-app/src/pages/work-log/task/params.ts
@@ -28,7 +28,6 @@ export default function TaskSummaryPageParams() {
     () => !Object.values(isDirtyRecord).every((value) => value === false),
     [isDirtyRecord]
   );
-  console.log(isDirtyRecord);
 
   const initialRef = taskSummaryData.reduce<
     Record<number, RefObject<TaskSummaryTableBodyHandle | null>>
@@ -84,6 +83,11 @@ export default function TaskSummaryPageParams() {
   }, []);
   const isAnyItemSelected = !!selectedItemId;
 
+  // なびげーしょん
+  const navigateToDetail = useCallback(
+    () => console.log("移動先のid", selectedItemId),
+    [selectedItemId]
+  );
   return {
     /** タスク一覧 */
     taskSummaryData,
@@ -105,5 +109,7 @@ export default function TaskSummaryPageParams() {
     handleSelectItem,
     /** いずれかのアイテムが選択されているか */
     isAnyItemSelected,
+    /** 詳細ページへのナビゲーション */
+    navigateToDetail,
   };
 }


### PR DESCRIPTION
 タイトル通り

# 詳細
- 選択中のアイテムのidから詳細ページへナビゲーションするロジックを作成
  - 現在はナビゲーションの方法は未実装なので、console.logで移動先のid出すだけ

# 変更予定
- param.ts -> useTaskSummaryPage.ts
  - nav.tsとparam.tsにしようとしたけどnavロジックがほぼなかったので　まとめる
  - 現在はparam.tsに書いてるけど、これを変更する予定