### PR TITLE
type:タスク詳細ページ用のメモの型定義

### DIFF
--- a/my-app/src/type/Memo.ts
+++ b/my-app/src/type/Memo.ts
@@ -49,3 +49,16 @@ export type MemoDailyTask = {
   /** 関連する日付のタスク */
   task: TaskOption;
 };
+
+export type MemoTaskDetail = {
+  /** 識別用のid */
+  id: number;
+  /** 書いた日付 */
+  date: Date;
+  /** メモのタイトル */
+  title: string;
+  /** タグ(任意) */
+  tag: string;
+  /** メモの本文の頭の方だけ */
+  summary: string;
+};


### PR DESCRIPTION
# 詳細
- 識別用のid(詳細受け取る時に使用)
- 日付(表示用)
- タイトル(表示用)
- タグ(表示用)
- 本文抜粋(表示用)