### PR TITLE
feature:とりあえず行作成

### DIFF
--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.stories.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import MemoListRow from "./MemoListRow";
+
+const meta = {
+  component: MemoListRow,
+  args: {
+    memoItem: {
+      id: 1,
+      date: new Date(),
+      title: "メモのタイトル",
+      tag: "何かしらのタグ",
+      summary: "ほんぶんの一部分、頭の部分を抜粋して表示している",
+    },
+    isActive: false,
+    onClickRow: () => {},
+  },
+} satisfies Meta<typeof MemoListRow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Active: Story = { args: { isActive: true } };

--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
@@ -1,0 +1,78 @@
+import { TableCell, TableRow, Collapse, Box, IconButton } from "@mui/material";
+import AspectRatioIcon from "@mui/icons-material/AspectRatio";
+import { MemoTaskDetail } from "@/type/Memo";
+import MemoListRowLogic from "./MemoListRowLogic";
+
+type Props = {
+  /** メモ */
+  memoItem: MemoTaskDetail;
+  /** アクティブ状態(アクティブであれば詳細を表示可能) */
+  isActive: boolean;
+  /** クリックされた時のハンドラ */
+  onClickRow: (id: number) => void;
+};
+/**
+ * タスク詳細ページ 行のコンポーネント
+ */
+export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
+  const { dateString } = MemoListRowLogic({ memoItem });
+  return (
+    <>
+      <TableRow
+        hover
+        selected={isActive}
+        onClick={() => onClickRow(memoItem.id)}
+        sx={{ "& > *": { borderBottom: "unset" } }} // 内部の子全てにボーダーを消すスタイルを適応
+      >
+        {/** 日付 */}
+        <TableCell
+          sx={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {dateString}
+        </TableCell>
+        {/** タイトル */}
+        <TableCell
+          sx={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {memoItem.title}
+        </TableCell>
+        {/** タグ */}
+        <TableCell
+          sx={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {memoItem.tag}
+        </TableCell>
+        {/** 展開ボタン */}
+        <TableCell>
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation(); // rowのイベント(文章の頭を展開する)を行わせない
+            }}
+          >
+            <AspectRatioIcon />
+          </IconButton>
+        </TableCell>
+      </TableRow>
+      <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={4}>
+          <Collapse in={isActive} timeout="auto" unmountOnExit>
+            <Box margin={1}>{memoItem.summary}</Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+      {/** TODO:ここで詳細のダイアログ */}
+    </>
+  );
+}

--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRowLogic.ts
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRowLogic.ts
@@ -1,0 +1,24 @@
+import { MemoTaskDetail } from "@/type/Memo";
+import { format } from "date-fns";
+import { useMemo } from "react";
+
+type Props = {
+  /** メモ */
+  memoItem: MemoTaskDetail;
+};
+
+/**
+ * タスク詳細ページ 行のコンポーネントのロジック
+ */
+export default function MemoListRowLogic({ memoItem }: Props) {
+  // メモの日付のstring
+  const dateString = useMemo(
+    () => format(memoItem.date, "yyyy/MM/dd"),
+    [memoItem.date]
+  );
+
+  return {
+    /** メモの日付(string) */
+    dateString,
+  };
+}


### PR DESCRIPTION
基本的な構造は日付ページのそれと同じ
# 詳細
- タイトルとかを列で表示
- 右端の列には詳細ダイアログ用のボタン
  - これの実装は次行う予定なので、今は押しても何も起きない
- アクティブになると展開
  - 本文の一部(summary)を表示する
  - アクティブ状態の管理は親で(選択されている行はテーブル中で1行のみにしたい ->テーブルが管理する必要がある)

# 日付ページから分離すべきかどうか
- 結論からいうと今の実装分は分離する必要性なし
  - 内容が一致しないため、分離する場合は「行数」「タイトルの配列」などをpropにする必要がある
  - 展開する行についてはCollaspeで行ってるだけなのでそんないらん気がする
- 総担をいうと「分離できるっちゃできる、けどする必要もないかも」ぐらい