### PR TITLE
feature:メモの編集/表示ダイアログ

### DIFF
--- a/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.stories.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import MemoListDialog from "./MemoListDialog";
+
+const meta = {
+  component: MemoListDialog,
+  args: {
+    id: 1,
+    title: "タイトル名",
+    tagId: 1,
+    open: true,
+    onClose: () => {},
+  },
+} satisfies Meta<typeof MemoListDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.tsx
@@ -1,0 +1,174 @@
+import {
+  CircularProgress,
+  Dialog,
+  FormControl,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditNoteIcon from "@mui/icons-material/EditNote";
+import SaveIcon from "@mui/icons-material/Save";
+import { Controller } from "react-hook-form";
+import ConfirmDeleteDialog from "@/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog";
+import useDialog from "@/hook/useDialog";
+import MemoListDialogLogic from "./MemoListDialogLogic";
+
+type Props = {
+  /** メモid */
+  id: number;
+  /** メモタイトル */
+  title: string;
+  /* タグid */
+  tagId: number;
+  /** ダイアログ開閉状態 */
+  open: boolean;
+  /** ダイアログを閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * タスク詳細 メモのダイアログ
+ */
+export default function MemoListDialog({
+  id,
+  title,
+  tagId,
+  open,
+  onClose,
+}: Props) {
+  const {
+    tagList,
+    isEdit,
+    control,
+    isLoading,
+    isSending,
+    handleEdit,
+    handleDelete,
+    onSubmit,
+  } = MemoListDialogLogic({
+    id,
+    title,
+    tagId,
+    onClose,
+  });
+  const {
+    open: openDelete,
+    onClose: onCloseDelete,
+    onOpen: onOpenDelete,
+  } = useDialog();
+  return (
+    <>
+      <Dialog open={open} onClose={isEdit ? () => {} : onClose} fullWidth>
+        {/** 全体 */}
+        <Stack spacing={1} px={2} py={2}>
+          {/** ヘッダー部分 */}
+          <form onSubmit={onSubmit}>
+            <Stack direction="row" justifyContent={"space-between"}>
+              {/** タイトル情報 */}
+              <Stack spacing={1} width="350px" pl={1} pb={2}>
+                {/** タイトル */}
+                <Stack direction="row" spacing="2" alignItems={"center"}>
+                  <Typography>タイトル：</Typography>
+                  <Controller
+                    name="title"
+                    control={control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        variant="standard"
+                        sx={{ flexGrow: 1 }}
+                        disabled={!isEdit}
+                      />
+                    )}
+                  />
+                </Stack>
+                {/** タグ */}
+                <Stack direction="row" spacing="2" alignItems={"center"}>
+                  <Typography> タグ：</Typography>
+                  {isLoading && <CircularProgress />}
+                  {!isLoading && (
+                    <FormControl sx={{ flexGrow: 1 }}>
+                      <Controller
+                        name="tagId"
+                        control={control}
+                        render={({ field }) => (
+                          <Select
+                            {...field}
+                            variant="standard"
+                            disabled={!isEdit}
+                          >
+                            {tagList.map((tag) => (
+                              <MenuItem key={tag.id} value={tag.id}>
+                                {tag.name}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        )}
+                      />
+                    </FormControl>
+                  )}
+                </Stack>
+              </Stack>
+              {/** アイコンボタン */}
+              <Stack direction="row" spacing={2} pr={3}>
+                <IconButton onClick={onOpenDelete} color="error">
+                  <DeleteIcon />
+                </IconButton>
+                {/** 編集中かどうかで保存/編集ボタンを切り替え */}
+                {isEdit && (
+                  <IconButton type="submit" color="primary" loading={isSending}>
+                    <SaveIcon />
+                  </IconButton>
+                )}
+                {!isEdit && (
+                  <IconButton
+                    disabled={isLoading}
+                    onClick={handleEdit}
+                    color="primary"
+                  >
+                    <EditNoteIcon />
+                  </IconButton>
+                )}
+              </Stack>
+            </Stack>
+            {/** 本文の部分 */}
+            {isLoading && (
+              <Stack
+                height="150px"
+                alignItems={"center"}
+                justifyContent={"center"}
+              >
+                <CircularProgress />
+              </Stack>
+            )}
+            {!isLoading && (
+              <Controller
+                name="text"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    fullWidth
+                    disabled={!isEdit}
+                    multiline
+                    rows={5}
+                    label="本文"
+                  />
+                )}
+              />
+            )}
+          </form>
+        </Stack>
+      </Dialog>
+      <ConfirmDeleteDialog
+        open={openDelete}
+        onClose={onCloseDelete}
+        onAccept={handleDelete}
+      />
+    </>
+  );
+}

--- a/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialogLogic.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialogLogic.tsx
@@ -1,0 +1,99 @@
+import { TagOption } from "@/type/Tag";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+type SubmitData = {
+  /** 本文 */
+  text: string;
+  /* タグid */
+  tagId: number;
+  /** タイトル */
+  title: string;
+};
+
+type Props = {
+  /** メモのid */
+  id: number;
+  /* タグid */
+  tagId: number;
+  /** メモのタイトル */
+  title: string;
+  /** ダイアログを閉じる関数 */
+  onClose: () => void;
+};
+
+/**
+ * タスク詳細 メモのダイアログのロジック
+ */
+export default function MemoListDialogLogic({
+  id,
+  tagId,
+  title,
+  onClose,
+}: Props) {
+  // TODO:idを使ってデータフェッチ
+  const text =
+    "本文の文章をなんかかいて、それがまとめて渡されるあああ、えええ、っっっでええあえふぁ";
+  const isLoading = id ? false : true;
+
+  // TODO:タグ一覧をデータフェッチ
+  const tagList: TagOption[] = [
+    { id: 1, name: "タグ1" },
+    { id: 2, name: "タグ2" },
+    { id: 3, name: "タグ3" },
+  ];
+
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [isSending, setIsSending] = useState<boolean>(false);
+  // RHF
+  const { control, handleSubmit, setValue } = useForm<SubmitData>({
+    defaultValues: { text: "", tagId: tagId, title: title },
+  });
+  // ロード完了時にsetValueで初期値をセットする
+  useEffect(() => {
+    if (!isLoading) {
+      setValue("text", text);
+    }
+  }, [isLoading, setValue]);
+
+  const onSubmit = useCallback(
+    async (data: SubmitData) => {
+      //TODO:データ送信処理
+      setIsSending(true);
+      console.log("そうしんでーた", data);
+      console.log("送信先id", id);
+      if (true) {
+        // TODO: データのレスポンスに応じて分岐
+        setIsSending(false);
+        setIsEdit(false);
+      }
+    },
+    [id]
+  );
+
+  const handleDelete = useCallback(async () => {
+    // TODO: 削除のリクエスト
+    console.log("削除対象のid", id);
+    onClose();
+  }, [id, onClose]);
+
+  const handleEdit = useCallback(() => setIsEdit(true), []);
+  return {
+    /** タグ一覧 */
+    tagList,
+    /** 編集状態かどうか */
+    isEdit,
+    /** RHFのコントロールオブジェクト(MUIコンポーネント管理に使用) */
+    control,
+    /** ロード状態 */
+    isLoading,
+    /** 送信の状態 */
+    isSending,
+    /** 送信時のハンドラー */
+    onSubmit: handleSubmit(onSubmit),
+    /** 編集状態に入るときのハンドラー */
+    handleEdit,
+    /** 削除時のハンドラー */
+    handleDelete,
+  };
+}


### PR DESCRIPTION
基本構造は日付ページのそれと一緒

# 詳細
- 日付ページのと違い
  - フォーム追加
    - タイトル(Textfield)
    - タグ(Select)
    - どちらもRHFで管理
  - パラメータ変更
    - 削除
      - タスク名
    - 追加
      - タグ名
- 各フォームについてはisEdit=trueの場合のみ編集が可能