### PR TITLE
feature:ダイアログと行のコンポーネントを合体

### DIFF
--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.stories.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
       id: 1,
       date: new Date(),
       title: "メモのタイトル",
-      tag: "何かしらのタグ",
+      tag: "タグ2",
       summary: "ほんぶんの一部分、頭の部分を抜粋して表示している",
     },
     isActive: false,

--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
@@ -2,6 +2,8 @@ import { TableCell, TableRow, Collapse, Box, IconButton } from "@mui/material";
 import AspectRatioIcon from "@mui/icons-material/AspectRatio";
 import { MemoTaskDetail } from "@/type/Memo";
 import MemoListRowLogic from "./MemoListRowLogic";
+import MemoListDialog from "../dialog/MemoListDialog";
+import useDialog from "@/hook/useDialog";
 
 type Props = {
   /** メモ */
@@ -16,6 +18,7 @@ type Props = {
  */
 export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
   const { dateString } = MemoListRowLogic({ memoItem });
+  const { open, onClose, onOpen } = useDialog();
   return (
     <>
       <TableRow
@@ -59,6 +62,7 @@ export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
           <IconButton
             onClick={(e) => {
               e.stopPropagation(); // rowのイベント(文章の頭を展開する)を行わせない
+              onOpen();
             }}
           >
             <AspectRatioIcon />
@@ -73,6 +77,15 @@ export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
         </TableCell>
       </TableRow>
       {/** TODO:ここで詳細のダイアログ */}
+      <MemoListDialog
+        id={memoItem.id}
+        title={memoItem.title}
+        tagId={
+          1 /** TODO:後で修正(ダイアログがname受け取ってそこから検索するように変更) */
+        }
+        open={open}
+        onClose={onClose}
+      />
     </>
   );
 }


### PR DESCRIPTION
 タイトル通り

# 詳細
- MemoListRowからDialogが開けるように
  - rowから各情報を渡す

# 注意点
- paramについて
  - ダイアログがtagIdを求めていますが、データ一覧ではidが不要であるため保持しておらず、渡すことができない
  - 全体データでidつけても特に利用されないので、ダイアログが受け取るデータをタグ名に変更してダイアログ内でidを取得させる方向で変更予定
  - ので、次回ダイアログの修正を行う予定