### PR TITLE
Feature/update dialog param

### DIFF
--- a/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialog.tsx
@@ -22,8 +22,8 @@ type Props = {
   id: number;
   /** メモタイトル */
   title: string;
-  /* タグid */
-  tagId: number;
+  /* タグ名 */
+  tagName: string;
   /** ダイアログ開閉状態 */
   open: boolean;
   /** ダイアログを閉じる関数 */
@@ -36,7 +36,7 @@ type Props = {
 export default function MemoListDialog({
   id,
   title,
-  tagId,
+  tagName,
   open,
   onClose,
 }: Props) {
@@ -52,7 +52,7 @@ export default function MemoListDialog({
   } = MemoListDialogLogic({
     id,
     title,
-    tagId,
+    tagName,
     onClose,
   });
   const {

--- a/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialogLogic.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/dialog/MemoListDialogLogic.tsx
@@ -14,8 +14,8 @@ type SubmitData = {
 type Props = {
   /** メモのid */
   id: number;
-  /* タグid */
-  tagId: number;
+  /* タグ名 */
+  tagName: string;
   /** メモのタイトル */
   title: string;
   /** ダイアログを閉じる関数 */
@@ -27,7 +27,7 @@ type Props = {
  */
 export default function MemoListDialogLogic({
   id,
-  tagId,
+  tagName,
   title,
   onClose,
 }: Props) {
@@ -42,6 +42,9 @@ export default function MemoListDialogLogic({
     { id: 2, name: "タグ2" },
     { id: 3, name: "タグ3" },
   ];
+
+  // タグ名から検索してidを取得する
+  const tagId = tagList.find((tagItem) => tagItem.name === tagName)?.id;
 
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [isSending, setIsSending] = useState<boolean>(false);

--- a/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
+++ b/my-app/src/pages/work-log/task/:id/memo-list/row/MemoListRow.tsx
@@ -76,13 +76,11 @@ export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
           </Collapse>
         </TableCell>
       </TableRow>
-      {/** TODO:ここで詳細のダイアログ */}
+      {/** 詳細のダイアログ */}
       <MemoListDialog
         id={memoItem.id}
         title={memoItem.title}
-        tagId={
-          1 /** TODO:後で修正(ダイアログがname受け取ってそこから検索するように変更) */
-        }
+        tagName={memoItem.tag}
         open={open}
         onClose={onClose}
       />


### PR DESCRIPTION
# 変更点
- ダイアログのpropのパラメータを変更

# 詳細
- tagId:numer => tagName:stringにパラメータを変更
  - 親ではタグ名しか扱わないため、idを受け取ることができないので
  - 送信データなどフォームの型定義はtagIdのまま
- ダイアログでフェッチする予定のタグの一覧データから合致する項目を探して、idを取得するように設定
  - この値を用いて元々の実装の分と合致させる