### PR TITLE
feature:メイン表示部分のコンポーネント作成

### DIFF
--- a/my-app/src/pages/work-log/task/:id/main-display/MainDisplay.stories.tsx
+++ b/my-app/src/pages/work-log/task/:id/main-display/MainDisplay.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import MainDisplay from "./MainDisplay";
+
+const meta = {
+  component: MainDisplay,
+  args: {
+    taskName: "taskName",
+    isFavorite: false,
+    categoryName: "categoryName",
+    progress: 50,
+    totalHours: 30,
+    onClickNavigateCategoryPage: () => {},
+  },
+} satisfies Meta<typeof MainDisplay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Favorite: Story = { args: { isFavorite: true } };

--- a/my-app/src/pages/work-log/task/:id/main-display/MainDisplay.tsx
+++ b/my-app/src/pages/work-log/task/:id/main-display/MainDisplay.tsx
@@ -1,0 +1,98 @@
+import { IconButton, Stack, Typography } from "@mui/material";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import StarIcon from "@mui/icons-material/Star";
+import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
+import MainDisplayLogic from "./MainDisplayLogic";
+
+type Props = {
+  /** タスク名 */
+  taskName: string;
+  /** お気に入りかどうか */
+  isFavorite: boolean;
+  /** カテゴリ名 */
+  categoryName: string;
+  /** 進捗 */
+  progress: number;
+  /** 稼働合計時間 */
+  totalHours: number;
+  /** カテゴリページに飛ぶボタンを押した際のハンドラー */
+  onClickNavigateCategoryPage: () => void;
+};
+
+/**
+ * タスク詳細ページのメイン部分の表示
+ */
+export default function MainDisplay({
+  taskName,
+  isFavorite,
+  categoryName,
+  progress,
+  totalHours,
+  onClickNavigateCategoryPage,
+}: Props) {
+  const { progressGrayBarWidth } = MainDisplayLogic({ progress });
+  return (
+    <Stack spacing={0.5}>
+      {/** タスク/ おきにいり */}
+      <Stack direction="row" justifyContent={"space-between"}>
+        <Stack direction="row" spacing={1.5}>
+          <Typography width={125} textAlign={"right"}>
+            タスク名:
+          </Typography>
+          <Typography>{taskName}</Typography>
+        </Stack>
+        {isFavorite && <StarIcon color="primary" />}
+        {!isFavorite && <StarBorderIcon />}
+      </Stack>
+      {/** カテゴリ */}
+      <Stack direction="row" alignItems={"center"} spacing={1.5}>
+        <Typography width={125} textAlign={"right"}>
+          カテゴリ名:
+        </Typography>
+        <Typography>{categoryName}</Typography>
+        <IconButton size="small" onClick={onClickNavigateCategoryPage}>
+          <ArrowCircleRightIcon />
+        </IconButton>
+      </Stack>
+      {/** 進捗 */}
+      <Stack direction="row" spacing={1.5}>
+        <Typography width={125} textAlign={"right"}>
+          進捗:
+        </Typography>
+        <Stack
+          direction="row-reverse"
+          sx={{
+            width: "70%",
+            height: 20,
+            background:
+              "linear-gradient(to right,rgb(188, 255, 249),rgb(71, 255, 74))",
+            borderRadius: 1,
+          }}
+        >
+          <Stack
+            sx={{
+              height: "100%",
+              width: "0%",
+              backgroundColor: "#eee",
+              animation: "grow 1s ease-out forwards",
+              "@keyframes grow": {
+                "0%": { width: "100%" },
+                "100%": {
+                  width: `${progressGrayBarWidth}%`,
+                },
+              },
+            }}
+          />
+        </Stack>
+        <Typography>{progress}%</Typography>
+      </Stack>
+      {/** 稼働合計 */}
+      <Stack direction="row" spacing={1.5}>
+        <Typography width={125} textAlign={"right"}>
+          稼働合計時間:
+        </Typography>
+        <Typography>{totalHours}(h)</Typography>
+      </Stack>
+    </Stack>
+  );
+}

--- a/my-app/src/pages/work-log/task/:id/main-display/MainDisplayLogic.ts
+++ b/my-app/src/pages/work-log/task/:id/main-display/MainDisplayLogic.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+
+type Props = {
+  /** 進捗 */
+  progress: number;
+};
+
+/**
+ * タスク詳細ページのメイン部分の表示のロジック
+ */
+export default function MainDisplayLogic({ progress }: Props) {
+  const progressGrayBarWidth = useMemo(() => 100 - progress, [progress]);
+
+  return {
+    /** 進行度のバーの灰色部分の長さ */
+    progressGrayBarWidth,
+  };
+}


### PR DESCRIPTION
# 詳細
- 各内容を表示
  - タスク名：そのまま表示
  - お気に入り：お気に入りかどうかでボーダーのみか色塗った状態かどっちか表示
  - カテゴリ名：そのまま表示 + となりにナビゲーションボタン(管理は親でさせる)
  - 進捗：cssによってアニメーション付けされている進捗率に応じたバーを表示+%を表示
  - 稼働合計時間：そのまま時間を表示
- それぞれのタイトル部分の長さ、位置を揃えて表示して整えた
- ナビゲーションのロジックについては親で管理させるのでここだと特になし