### PR TITLE
ui:各アクションボタンの幅を大きめに変更

### DIFF
--- a/my-app/src/pages/work-log/task/:id/action-buttons/ActionButtons.tsx
+++ b/my-app/src/pages/work-log/task/:id/action-buttons/ActionButtons.tsx
@@ -23,14 +23,14 @@ export default function ActionButtons({
   return (
     <Stack spacing={1.5} alignItems={"center"}>
       <Button
-        sx={{ width: "30%" }}
+        sx={{ width: "50%" }}
         startIcon={<EditIcon />}
         onClick={onClickEdit}
       >
         編集する
       </Button>
       <Button
-        sx={{ width: "30%" }}
+        sx={{ width: "50%" }}
         color="success"
         startIcon={<DoneIcon />}
         onClick={onClickComplete}
@@ -38,7 +38,7 @@ export default function ActionButtons({
         完了状態にする
       </Button>
       <Button
-        sx={{ width: "30%" }}
+        sx={{ width: "50%" }}
         color="error"
         startIcon={<DeleteForeverIcon />}
         onClick={onClickDelete}


### PR DESCRIPTION
# 変更点
- アクションボタンのボタン自身の幅を増加

# 詳細
- アクションボタンの<Button>の幅を変更
  - 30% -> 50%
- これによってページに配置した際にボタン内部のテキストが１行に収まって綺麗になる