### PR TITLE
Type/update task detail type

### DIFF
--- a/my-app/src/type/Task.ts
+++ b/my-app/src/type/Task.ts
@@ -35,7 +35,7 @@ export type TaskDetail = {
   id: number;
   /** タスク名 */
   name: string;
-  /** ピン付の有無 */
+  /** お気に入りかどうか */
   isFavorite: boolean;
   /** カテゴリー(navigation用のidつき) */
   category: CategoryOption;
@@ -47,7 +47,7 @@ export type TaskDetail = {
   startDate: Date;
   /** タスクの最終更新日 */
   lastDate: Date;
-  /** タスクのメモ */
+  /** タスクの詳細ページのメモ */
   memo: MemoTaskDetail[];
 };
 


### PR DESCRIPTION
# 変更点
- タスク詳細ページで使うデータの型定義を更新

# 詳細
- isPinned -> isFavorite に名称変更(Favoriteで使ってるので)
- categoryにidを付与(ナビゲーション用に)
- Memoの型定義をMemoListに合わせて変更(本文の抜粋など必要なデータが足りてなかったので)