### PR TITLE
Feature/task edit dialog rhf logic

### DIFF
--- a/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialog.tsx
+++ b/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialog.tsx
@@ -42,6 +42,7 @@ export default function TaskEditDialog({
     initialTaskName,
     initialCategoryId,
     initialIsFavorite,
+    onClose,
   });
   return (
     <Dialog fullWidth open={open} onClose={onClose}>

--- a/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialogLogic.ts
+++ b/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialogLogic.ts
@@ -18,6 +18,8 @@ type Props = {
   initialCategoryId: number;
   /** お気に入りの初期値 */
   initialIsFavorite: boolean;
+  /** 閉じるハンドラー */
+  onClose: () => void;
 };
 /**
  * タスク詳細ページでタスクを編集するダイアログのロジック
@@ -26,6 +28,7 @@ export default function TaskEditDialogLogic({
   initialTaskName,
   initialCategoryId,
   initialIsFavorite,
+  onClose,
 }: Props) {
   // TODO:ここでデータフェッチ
   const categoryList: CategoryOption[] = [
@@ -48,10 +51,14 @@ export default function TaskEditDialogLogic({
     }, // TODO: 初期値が必要
   });
 
-  const onSubmit = useCallback(async (data: SubmitData) => {
-    // TODO:ここで送信
-    console.log("送信でーた", data);
-  }, []);
+  const onSubmit = useCallback(
+    async (data: SubmitData) => {
+      // TODO:ここで送信
+      console.log("送信でーた", data);
+      onClose();
+    },
+    [onClose]
+  );
   return {
     /** カテゴリの一覧 */
     categoryList,


### PR DESCRIPTION
#147 #146  これらの依存関係あり(直接的にはそんな関係ないけど、どっちも元ファイルの作成を行なっている都合で関係あり)

# 変更点
- RHFのロジックを作成
- フォームの初期値を引数に追加
- 今回はロジックの実装のみ(適応してないので、コンポーネント側には特に影響ないです)

# 詳細
- RHFでフォームを管理するロジックを作成
  - 各フォームの値のnameを作成してSubmitDataとしてローカル型として定義
  - 必要なものをuseFormで取得
    - control:MUIをコントロールするのに必須
    - isValid:タスク名ない時とかに保存できないように
    - handleSubmit:isValidで監視するけど、一応念の為
  - RHF関連の関数を定義
    - onSubmit:データ送信の関数
- RHFで使うデフォ値をコンポーネントの引数に追加

# 注意点
- 今回はRHFのロジックの実装/初期値の引数追加だけ
  - 実際にコンポーネントへの実装は次回