### PR TITLE
fix:キャンセルボタンを押した際にダイアログが閉じなかった不具合

### DIFF
--- a/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialog.tsx
+++ b/my-app/src/pages/work-log/task/:id/dialog/task-edit/TaskEditDialog.tsx
@@ -111,7 +111,9 @@ export default function TaskEditDialog({
         </Stack>
         {/** ボタン */}
         <DialogActions>
-          <Button color="error">キャンセル</Button>
+          <Button color="error" onClick={onClose}>
+            キャンセル
+          </Button>
           <Button disabled={!isValid} type={"submit"}>
             保存
           </Button>


### PR DESCRIPTION
タイトル通り

# 詳細
- onClickイベントの設定漏れ
  - onCloseを適応して閉じられるように