### PR TITLE
UI/connect select menu dialog

### DIFF
--- a/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/dialog/PeriodSelectDialog.tsx
+++ b/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/dialog/PeriodSelectDialog.tsx
@@ -22,7 +22,7 @@ export default function PeriodSelectDialog({ open, onClose }: Props) {
   return (
     <Dialog fullWidth open={open} onClose={onClose}>
       <DialogTitle>期間を選択</DialogTitle>
-      <Stack direction="row" px={3} py={1.5} spacing={1} alignItems="center">
+      <Stack direction="row" px={3} py={1.5} spacing={2} alignItems="center">
         <Stack>
           <Typography variant="caption">開始期間</Typography>
           <PeriodSelectMenuButton


### PR DESCRIPTION
# 変更点
- ダイアログにメニューつきのボタンを組み込んで表示
- ダイアログのUI微調整

# 詳細
- 元々期間選択のSelectだった場所に作ったSelectMenuを組み込み
- ラベルがなくなったので、typoでメニューボタン上部に作成
- ちょいデザイン崩れたので全体のspacingを追加

# 注意点
- UIのみの実装なのでロジック部分は未実装
- メニューを開くのはメニュー側のロジックで行ってるので問題ないけど、セレクトで選択はできない