### PR TITLE
fix:開始と終了に同日を設定した際にisValid===falseとなって選択不能になっていた問題を解決

### DIFF
--- a/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/dialog/PeriodSelectDialogLogic.ts
+++ b/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/dialog/PeriodSelectDialogLogic.ts
@@ -138,7 +138,7 @@ export default function PeriodSelectDialogLogic({
     [getDataSelectRange, onClose]
   );
 
-  const isValid = startDate < endDate; // ここダイアログ操作中はどっちかは変化し続けるのでメモ化しない
+  const isValid = startDate <= endDate; // ここダイアログ操作中はどっちかは変化し続けるのでメモ化しない
   return {
     /** 開始年 */
     startYear,


### PR DESCRIPTION
タイトル通り

同日を選択時 -> その１日のデータを取らせる
この挙動を想定

ので、
startDateとendDateが同一である場合もisValid=trueとなるように修正