### PR TITLE
ラジオボタンの選択についてのロジックをせってい(親からもらうだけだけど)

### DIFF
--- a/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.stories.tsx
+++ b/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.stories.tsx
@@ -1,15 +1,17 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import PeriodSelector from './PeriodSelector';
+import PeriodSelector from "./PeriodSelector";
 
 const meta = {
   component: PeriodSelector,
+  args: {
+    selectRange: "last-month",
+    onChangeSelectRange: () => {},
+  },
 } satisfies Meta<typeof PeriodSelector>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {}
-};
+export const Default: Story = {};

--- a/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.tsx
+++ b/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.tsx
@@ -11,17 +11,32 @@ import {
 import PeriodSelectDialog from "./dialog/PeriodSelectDialog";
 import useDialog from "@/hook/useDialog";
 
+type Props = {
+  /** 選択中の範囲 */
+  selectRange: "last-month" | "all" | "select";
+  /** 選択中の範囲を変更するハンドラー */
+  onChangeSelectRange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
 /**
  * カテゴリ内のタスクの稼働を表示するグラフの期間を選択するラジオグループ
  */
-export default function PeriodSelector() {
+export default function PeriodSelector({
+  selectRange,
+  onChangeSelectRange,
+}: Props) {
   const { open, onClose, onOpen } = useDialog();
   return (
     <>
       <Stack direction="row">
         <FormControl>
           <FormLabel>表示期間</FormLabel>
-          <RadioGroup row sx={{ gap: 2 }}>
+          <RadioGroup
+            row
+            sx={{ gap: 2 }}
+            value={selectRange}
+            onChange={onChangeSelectRange}
+          >
             <FormControlLabel
               value="last-month"
               control={<Radio />}


### PR DESCRIPTION
タイトル通り

# 詳細
- 選択中のラジオグループの値を親から受け取り
  - stringのユニオン型(3種類) そんな使い回さないからマジックナンバー化はいらないかな？
- ラジオグループの切り替えを行うonChangeイベントのハンドラーを受け取り
- これで親でcontrolさせる形式になった