### PR TITLE
ダイアログを再度開いた際に前回開いた際の値が保持される問題を解決

### DIFF
--- a/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.tsx
+++ b/my-app/src/pages/work-log/category/task-activity-pie-chart/period-selector/PeriodSelector.tsx
@@ -74,13 +74,15 @@ export default function PeriodSelector({
           </RadioGroup>
         </FormControl>
       </Stack>
-      <PeriodSelectDialog
-        open={open}
-        onClose={onClose}
-        initialStartDate={startDate}
-        initialEndDate={endDate}
-        getDataSelectRange={getDataSelectRange}
-      />
+      {open && (
+        <PeriodSelectDialog
+          open={open}
+          onClose={onClose}
+          initialStartDate={startDate}
+          initialEndDate={endDate}
+          getDataSelectRange={getDataSelectRange}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
# 詳細
- ダイアログを閉じた際にダイアログと表示で同期ズレする問題を解決
  - ダイアログ内でstateで値を独自に管理しているため
  - openでない場合にアンマウントさせることで開くたびに親から初期値を受け取るように変更することで対応
    - stateの持ち上げでも解決可能だけど親の再レンダーを引き起こすだけなのでこっちで対応