### PR TITLE
Feature/category task list header

### DIFF
--- a/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.stories.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.stories.tsx
@@ -1,15 +1,14 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import CategoryTaskListHeader from './CategoryTaskListHeader';
+import CategoryTaskListHeader from "./CategoryTaskListHeader";
 
 const meta = {
   component: CategoryTaskListHeader,
+  args: { selectedValue: "in-progress", onChange: () => {} },
 } satisfies Meta<typeof CategoryTaskListHeader>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {}
-};
+export const Default: Story = {};

--- a/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.tsx
@@ -6,13 +6,23 @@ import {
 } from "@mui/material";
 import { memo } from "react";
 
+type Props = {
+  /** 選択中の値 */
+  selectedValue: "in-progress" | "all" | "completed";
+  /** 値を変更するハンドラー */
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
 /**
  * カテゴリページのタスクリストのヘッダー
  */
-const CategoryTaskListHeader = memo(function CategoryTaskListHeader() {
+const CategoryTaskListHeader = memo(function CategoryTaskListHeader({
+  selectedValue,
+  onChange,
+}: Props) {
   return (
     <FormControl>
-      <RadioGroup row>
+      <RadioGroup row value={selectedValue} onChange={onChange}>
         <FormControlLabel
           value="in-progress"
           control={<Radio />}


### PR DESCRIPTION
# 変更点
- カテゴリ内のタスク一覧を表示するリストのヘッダー部分を作成

# 詳細
- ラジオボタンを横向きに配置
-  表示するタスクを制御
  - 進行中/全て/完了済みから設定
  - これらの情報は親で管理させるのでpropとして受け取るだけ