### PR TITLE
Feature/category task table body

### DIFF
--- a/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.stories.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.stories.tsx
@@ -4,7 +4,13 @@ import CategoryTaskTableBody from "./CategoryTaskTableBody";
 
 const meta = {
   component: CategoryTaskTableBody,
-  args: { isFavorite: false, taskName: "タスク1", progress: 80 },
+  args: {
+    isFavorite: false,
+    taskName: "タスク1",
+    progress: 80,
+    taskId: 1,
+    onClickNavigate: () => {},
+  },
 } satisfies Meta<typeof CategoryTaskTableBody>;
 
 export default meta;

--- a/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.tsx
@@ -11,6 +11,10 @@ type Props = {
   taskName: string;
   /** 進捗率 */
   progress: number;
+  /** タスクのid(移動用) */
+  taskId: number;
+  /** 移動ボタンを押した際のハンドラー */
+  onClickNavigate: (id: number) => void;
 };
 
 /**
@@ -20,6 +24,8 @@ const CategoryTaskTableBody = memo(function CategoryTaskTableBody({
   isFavorite,
   taskName,
   progress,
+  taskId,
+  onClickNavigate,
 }: Props) {
   return (
     <TableRow>
@@ -34,7 +40,7 @@ const CategoryTaskTableBody = memo(function CategoryTaskTableBody({
       <TableCell>{progress}%</TableCell>
       {/** 詳細へ移動するボタン */}
       <TableCell>
-        <IconButton>
+        <IconButton onClick={() => onClickNavigate(taskId)}>
           <DoubleArrowIcon />
         </IconButton>
       </TableCell>


### PR DESCRIPTION
# 変更点
- 必要なパラメータを追加してそれぞれ適応

# 詳細
- 表示用
  - タスク名を受け取ってまんま表示
  - 進捗を受け取って%つけて表示  
- 表示の分岐
  - お気に入りかどうか受け取って分岐
    - お気に入りなら青く塗りつぶされた星のアイコンを表示
    - そうでないなら黒のボーダーの星のアイコンを表示
- ナビゲーション
  - 移動先のタスクidを受け取る
  - 移動用の関数を受け取る
    - 引数にタスクidを与える