### PR TITLE
UI/update category task table body

### DIFF
--- a/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/table/body/CategoryTaskTableBody.tsx
@@ -35,7 +35,16 @@ const CategoryTaskTableBody = memo(function CategoryTaskTableBody({
         {isFavorite && <StarIcon color="primary" />}
       </TableCell>
       {/** タスク名 */}
-      <TableCell sx={{ pl: 3 }}>{taskName}</TableCell>
+      <TableCell
+        sx={{
+          pl: 3,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {taskName}
+      </TableCell>
       {/** 進捗 */}
       <TableCell sx={{ pl: 3 }}>{progress}%</TableCell>
       {/** 詳細へ移動するボタン */}


### PR DESCRIPTION
# 変更点
- ヘッダーに対してボディがずれて表示されていたのを調整
- タスク名が長い場合に省略表示するように設定

# 詳細
- ボディのuiを調整
  - 配置について
    - cell内部の左方向paddingを増加させて全体的に右寄りになるように調整してヘッダーの位置と合わせる
  - タスク名について
    - タスク名が長い場合に２行にわたって表示されてテーブルが崩れる恐れがあるため、セルの長さより長い場合は省略して表示するように設定