### PR TITLE
ui:とりあえずつなぎこみして調整

### DIFF
--- a/my-app/src/pages/work-log/category/page.stories.tsx
+++ b/my-app/src/pages/work-log/category/page.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Page from './page';
+
+const meta = {
+  component: Page,
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {}
+};

--- a/my-app/src/pages/work-log/category/page.tsx
+++ b/my-app/src/pages/work-log/category/page.tsx
@@ -1,0 +1,27 @@
+import { Stack } from "@mui/material";
+import CategorySelect from "./category-select/CategorySelect";
+import TaskActivityPieChart from "./task-activity-pie-chart/TaskActivityPieChart";
+import CategoryTaskList from "./category-task-list/CategoryTaskList";
+
+/**
+ * カテゴリページ
+ */
+export default function CategoryPage() {
+  return (
+    <Stack direction="row" p={1.5}>
+      {/** 左側(カテゴリ選択/期間グラフ) */}
+      <Stack width="50%" justifyContent={"space-around"}>
+        <CategorySelect
+          categoryOptions={[]}
+          selectedCategoryId={1}
+          onChangeCategoryId={() => {}}
+        />
+        <TaskActivityPieChart categoryId={1} />
+      </Stack>
+      {/** 右側(カテゴリ内タスクリスト) */}
+      <Stack width="50%" height={500} pt={15}>
+        <CategoryTaskList categoryId={1} />
+      </Stack>
+    </Stack>
+  );
+}


### PR DESCRIPTION
タイトル通り

# 詳細
- Stackで配置 paddingで周りに余白を確保
  - 左右に50%ずつ幅持たせて配置
    - 左にはカテゴリ選択と稼働グラフを表示
      - justifyContent="space-around"で間隔を確保
    - 右にはタスク一覧を表示
      - ptで上部に余白を確保
      - heightを固定値にしてアイテムが多い場合にスクロールできるように変更