### PR TITLE
UI/update task list header

### DIFF
--- a/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.tsx
+++ b/my-app/src/pages/work-log/category/category-task-list/header/CategoryTaskListHeader.tsx
@@ -1,6 +1,7 @@
 import {
   FormControl,
   FormControlLabel,
+  FormLabel,
   Radio,
   RadioGroup,
 } from "@mui/material";
@@ -22,6 +23,7 @@ const CategoryTaskListHeader = memo(function CategoryTaskListHeader({
 }: Props) {
   return (
     <FormControl sx={{ pl: 2 }}>
+      <FormLabel>表示するタスク</FormLabel>
       <RadioGroup row value={selectedValue} onChange={onChange} sx={{ gap: 3 }}>
         <FormControlLabel
           value="in-progress"


### PR DESCRIPTION
# 変更点
- カテゴリーのタスク一覧のヘッダーのUI調整

# 詳細
- 表示するタスクをフィルターするラジオボタンについて
  - サイズをグラフのそれに合わせて変更(サイズ縮小とpaddingの削除)
  - わかりにくかったのでラベル追加