### PR TITLE
UI/update task table out header

### DIFF
--- a/my-app/src/pages/work-log/main/page.tsx
+++ b/my-app/src/pages/work-log/main/page.tsx
@@ -8,7 +8,7 @@ import TaskTable from "./table/TaskTable";
  */
 export default function MainPage() {
   return (
-    <Stack direction="row" p={2} justifyContent={"space-between"} height={600}>
+    <Stack direction="row" p={2} justifyContent={"space-between"} height={650}>
       <NavMenu />
       <Stack spacing={2}>
         <MainPagePieChart />

--- a/my-app/src/pages/work-log/main/table/TaskTable.tsx
+++ b/my-app/src/pages/work-log/main/table/TaskTable.tsx
@@ -28,11 +28,15 @@ const TaskTable = memo(function TaskTable() {
           <TableHead>
             <TableRow>
               {/** タスク名 */}
-              <TableCell width={"60%"}>タスク名</TableCell>
+              <TableCell width={"60%"} sx={{ py: 1 }}>
+                タスク名
+              </TableCell>
               {/** 進捗 */}
-              <TableCell width={"30%"}>進捗</TableCell>
+              <TableCell width={"30%"} sx={{ py: 1 }}>
+                進捗
+              </TableCell>
               {/** ボタン部分 */}
-              <TableCell width={"10%"}></TableCell>
+              <TableCell width={"10%"} sx={{ py: 1 }}></TableCell>
             </TableRow>
           </TableHead>
           {/** ボディ */}
@@ -40,11 +44,11 @@ const TaskTable = memo(function TaskTable() {
             {data.map((item) => (
               <TableRow key={item.id}>
                 {/** タスク名 */}
-                <TableCell>{item.name}</TableCell>
+                <TableCell sx={{ py: 1 }}>{item.name}</TableCell>
                 {/** 進捗 */}
-                <TableCell>{item.progress}</TableCell>
+                <TableCell sx={{ py: 1 }}>{item.progress}</TableCell>
                 {/** ボタン部分 */}
-                <TableCell>
+                <TableCell sx={{ py: 1 }}>
                   <IconButton onClick={() => navigateToDetail(item.id)}>
                     <DoubleArrowIcon />
                   </IconButton>


### PR DESCRIPTION
# 変更点
- テーブルの外部に文言のヘッダーを追加
- 全体のサイズを調整
# 詳細
- テーブルをフラグメントで囲って外部にTypoでタイトル追加
  - フォントやサイズはグラフと同様に設定
- タイトル追加分のサイズ調整
  - cellのy軸のpaddingを2(デフォ) => 1に変更
  - ページ全体のheigthを調整