### PR TITLE
タスク詳細ページを開いた際にNavBarに文言が表示されない問題を解決

### DIFF
--- a/my-app/src/component/Navbar/logic.ts
+++ b/my-app/src/component/Navbar/logic.ts
@@ -15,11 +15,9 @@ const exchangePathName = (nameList: string[], name: string, index: number) => {
       return "カテゴリ";
     // これら以外の場合
     default:
-      // [id]に当たる場合(Number化した時にNaNでない場合) ->一つ前の値がタスクかカテゴリかで分岐
-      if (isNaN(Number(name))) {
-        if (nameList[index - 1] === "daily") return "日付(詳細)";
-        if (nameList[index - 1] === "task") return "タスク(詳細)";
-      }
+      // 一つ前の値がタスクかカテゴリかで分岐
+      if (nameList[index - 1] === "daily") return "日付(詳細)";
+      if (nameList[index - 1] === "task") return "タスク(詳細)";
       // 該当しなければ空白を返す
       return "";
   }


### PR DESCRIPTION
タイトル通り

# 詳細
- 分岐が誤ってたので修正
  - 修正前:isNaNの分岐が逆だった(Numberであれば行いたいのに、NaNの場合に分岐を有効にしていた)
  - 修正後:isNaNの分岐自体不要だったので削除 ->一つ前のページがtaskであればタスク(詳細),dailyであれば日付(詳細)と表示

# 注意点
- もし今後ページを追加する場合は要修正(switch増やして、まー該当なしでタスク(詳細)とすれば問題ないと思われる)