### PR TITLE
型定義名わかりにくかったので変更して不要なidも削除

### DIFF
--- a/my-app/src/app/work-log/daily/dialog/DateDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/dialog/DateDialogLogic.ts
@@ -1,6 +1,6 @@
 import { SelectChangeEvent } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
-import { DateDetail } from "@/type/Date";
+import { DateSummaryDetail } from "@/type/Date";
 import {
   dayBeforeYesterdayDate,
   dayBeforeYesterdayMonth,
@@ -44,9 +44,8 @@ export default function DataDialogLogic() {
   );
 
   // TODO:データフェッチさせる
-  const dateDetails: DateDetail = useMemo(() => {
+  const dateDetails: DateSummaryDetail = useMemo(() => {
     return {
-      id: 0,
       date: new Date(),
       categoryList: [
         {

--- a/my-app/src/type/Date.ts
+++ b/my-app/src/type/Date.ts
@@ -17,9 +17,7 @@ export type DateSummary = {
 };
 
 /** 日付の詳細データ型 */
-export type DateDetail = {
-  /** 識別用のid */
-  id: number;
+export type DateSummaryDetail = {
   /** 日付 */
   date: Date;
   /** 割合つきのカテゴリリスト */


### PR DESCRIPTION
タイトル通り
dailyページ関連はidいらないので削除
DailySummaryページのDetailであることを強調した型定義名に変更