### PR TITLE
Feature/update task table get task category options

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -49,6 +49,7 @@ export default function TaskEditDialog({
     dailyHours,
     unSelected,
     taskList,
+    isTaskSelectAvailable,
     categoryList,
     onChangeSelectCategory,
     onChangeSelectTask,
@@ -120,7 +121,7 @@ export default function TaskEditDialog({
               {/** セレクト */}
               <FormControl fullWidth>
                 <InputLabel id="task-select-label">タスク</InputLabel>
-                {taskList && (
+                {isTaskSelectAvailable && (
                   <Select
                     labelId="task-select-label"
                     id="task-select"
@@ -129,7 +130,7 @@ export default function TaskEditDialog({
                     onChange={onChangeSelectTask}
                     label="タスク"
                   >
-                    {taskList.map((task) => (
+                    {taskList!.map((task) => (
                       <MenuItem
                         key={task.id}
                         value={task.id}

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -1,7 +1,7 @@
 import apiClient from "@/lib/apiClient";
 import useAspidaSWR from "@aspida/swr";
 import { SelectChangeEvent } from "@mui/material";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type Props = {
   /** 今開いてる対象のデータのid */
@@ -48,6 +48,10 @@ export default function TaskEditDialogLogic({
       setTaskId(taskList[0].id);
     }
   }, [taskList]);
+  const isTaskSelectAvailable = useMemo(
+    () => taskList && taskList.some((v) => v.id === taskId),
+    [taskId, taskList]
+  );
   const onChangeSelectCategory = useCallback((e: SelectChangeEvent) => {
     const target = e.target.value;
     setCategoryId(Number(target));
@@ -84,6 +88,8 @@ export default function TaskEditDialogLogic({
     categoryList,
     /** タスク一覧(カテゴリを変更時には再度取得する必要あり) */
     taskList,
+    /** タスクの選択が有効かどうか(taskListの有無+選択値のidがtaskListに存在するかで判別) */
+    isTaskSelectAvailable,
     /** 選択したカテゴリーに変更するハンドラー */
     onChangeSelectCategory,
     /** 選択したタスクに変更するハンドラー */


### PR DESCRIPTION
# 変更点
- タスク編集ダイアログ開いた際にタスク一覧とカテゴリ一覧を取得できるように変更

# 詳細
- すでに作成済みのtasks/options,categories/optionsのエンドポイントから各データを取得
- ロジックを修正
  - カテゴリ変更時にタスクのidをnullにセットするように変更
  - その後、カテゴリが変更されたのをトリガーにしてtaskListが再フェッチされる
  - useEffectでタスクの選択値がタスクリストの先頭に変更されるように変更
    - 前のタスクのidを引用してしまうのの対策
  - Selectのout of rangeエラー対策で選択不能な値を指定している際にはSelectを描画しないように変更
    - taskListがない時も含む
    - Array.some()でtaskIdがtaskListに含まれてるかで判別