### PR TITLE
Feature/update task edit dialog open logic

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -61,6 +61,7 @@ export default function TaskEditDialog({
     initialCategoryId,
     initialTaskId,
     initialHours,
+    onClose,
   });
   const {
     open: openDelete,

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -14,6 +14,8 @@ type Props = {
   initialTaskId: number;
   /** 稼働時間の初期選択の値 */
   initialHours: number;
+  /** ダイアログ閉じるイベント */
+  onClose: () => void;
 };
 
 /**
@@ -24,6 +26,7 @@ export default function TaskEditDialogLogic({
   initialCategoryId,
   initialTaskId,
   initialHours,
+  onClose,
 }: Props) {
   // ぱらめーた
   const { date } = useParams<{ date: string }>();
@@ -97,11 +100,13 @@ export default function TaskEditDialogLogic({
       .task_logs._id(itemId)
       .patch({ body: body });
     mutate(`api/work-log/daily/${date}`); // 再検証する
-  }, [dailyHours, date, itemId, taskId]);
+    onClose();
+  }, [dailyHours, date, itemId, onClose, taskId]);
   const handleDelete = useCallback(async () => {
     await apiClient.work_log.daily._date(date).task_logs._id(itemId).delete();
     mutate(`api/work-log/daily/${date}`); // 再検証する
-  }, [date, itemId]);
+    onClose();
+  }, [date, itemId, onClose]);
   return {
     /** 選択中のカテゴリーのid */
     categoryId,


### PR DESCRIPTION
# 変更点
- タスク編集ダイアログの開いた時のロジックを更新
- 開閉のロジックも更新

# 詳細
- 開いた時
  - useEffectでのtaskIdの更新について、初期レンダーのフラグをrefに保持させて初回は行わないようにする
  - これで開いた際には初期値が利用できるようになる
- 開閉
  - 保存/削除時にダイアログを閉じるように変更