### PR TITLE
DailyTable メモがない場合の分岐を追加(memo[0].titleへのアクセスをしないようにしつつ、展開っぽいアイコンを非表示に変更

### DIFF
--- a/my-app/src/app/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/app/work-log/daily/table/DailyTable.tsx
@@ -122,7 +122,10 @@ export default function DailyTable({ itemList, isLoading, onClickRow }: Props) {
                         borderRadius: "4px",
                         transition: "background 0.5s",
                         "&:hover": {
-                          backgroundColor: "rgba(31, 158, 255, 0.37)",
+                          backgroundColor:
+                            item.memo.length > 0
+                              ? "rgba(31, 158, 255, 0.37)"
+                              : "",
                         },
                       }}
                       onMouseEnter={(e) =>
@@ -130,21 +133,25 @@ export default function DailyTable({ itemList, isLoading, onClickRow }: Props) {
                       }
                       onMouseLeave={() => handleMouseLeave(dateToId(item.date))}
                     >
-                      <Typography
-                        sx={{
-                          overflow: "hidden",
-                          whiteSpace: "nowrap",
-                          textOverflow: "ellipsis",
-                        }}
-                      >
-                        {item.memo[0].title}
-                      </Typography>
-                      <KeyboardArrowDownIcon
-                        sx={{
-                          opacity: 0.6,
-                          fontSize: 20,
-                        }}
-                      />
+                      {item.memo.length > 0 && (
+                        <>
+                          <Typography
+                            sx={{
+                              overflow: "hidden",
+                              whiteSpace: "nowrap",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {item.memo[0].title}
+                          </Typography>
+                          <KeyboardArrowDownIcon
+                            sx={{
+                              opacity: 0.6,
+                              fontSize: 20,
+                            }}
+                          />
+                        </>
+                      )}
                     </TableCell>
                     {/** 稼働合計 */}
                     <TableCell


### PR DESCRIPTION
タイトル通り

# 詳細
- メモが存在しない場合にmemo[0].titleを参照した際のエラーを解消
  - memo.lengthを調べて0の場合は非表示にすることで参照しないように変更
  - ついでにアイコンも囲って非表示に変更