### PR TITLE
特定の日付詳細ページへダイアログから移動する際にパラメータが誤ってたので修正

### DIFF
--- a/my-app/src/app/work-log/daily/dialog/DateDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/dialog/DateDialogLogic.ts
@@ -44,7 +44,10 @@ export default function DataDialogLogic() {
   );
 
   const dateParam = useMemo(
-    () => `${selectYear}-${selectMonth}-${selectDay}`,
+    () =>
+      `${selectYear}-${selectMonth.toString().padStart(2, "0")}-${selectDay
+        .toString()
+        .padStart(2, "0")}`,
     [selectDay, selectMonth, selectYear]
   );
   const { data, isLoading } = useAspidaSWR(


### PR DESCRIPTION
タイトル通り

# 詳細
- 以下の問題を修正
  - 詳細ページへ移動 -> dbにデータがない場合に新規作成 -> 1日前の15:00:00のデータが作成される問題
    - パスパラメータに誤り(月日を02などにするところを2にしていたため)
  - 詳細ページでの変更が一覧に反映されない問題
    - 上記を解決したことで同期可能に