### PR TITLE
グローバルに設定していたアニメーションを固有のアニメーションに変更(ページ間で同じ値が利用されるバグを修正するため)

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenu.tsx
+++ b/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenu.tsx
@@ -31,12 +31,11 @@ export default function DailyDetailMenu({ date, dailyHours, taskList }: Props) {
     onClose: onCloseMemo,
     onOpen: onOpenMemo,
   } = useDialog();
-  const { dateString, dailyHourCoverGraphLength, isNoTask } =
-    DailyDetailMenuLogic({
-      date,
-      dailyHours,
-      taskList,
-    });
+  const { dateString, growAnimation, isNoTask } = DailyDetailMenuLogic({
+    date,
+    dailyHours,
+    taskList,
+  });
   return (
     <>
       <Stack spacing={2}>
@@ -60,13 +59,7 @@ export default function DailyDetailMenu({ date, dailyHours, taskList }: Props) {
                   height: "100%",
                   width: "0%",
                   backgroundColor: "#eee",
-                  animation: "grow 1s ease-out forwards",
-                  "@keyframes grow": {
-                    "0%": { width: "100%" },
-                    "100%": {
-                      width: `${dailyHourCoverGraphLength}%`,
-                    },
-                  },
+                  animation: `${growAnimation} 1s ease-out forwards`,
                 }}
               />
             </Stack>

--- a/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenuLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenuLogic.ts
@@ -1,4 +1,5 @@
 import { TaskLogSummary } from "@/type/Task";
+import { keyframes } from "@emotion/react";
 import { format } from "date-fns";
 import { useMemo } from "react";
 
@@ -21,17 +22,25 @@ export default function DailyDetailMenuLogic({
 }: Props) {
   // Date => YYYY/MM/DDに変換する
   const dateString = useMemo(() => format(date, "yyyy/MM/dd"), [date]);
-  const dailyHourCoverGraphLength = useMemo(
-    () => (10 - dailyHours) * 10,
-    [dailyHours]
-  );
+
+  const growAnimation = useMemo(() => {
+    const dailyHourCoverGraphLength = (10 - dailyHours) * 10;
+    return keyframes`
+  0% {
+    width: 100%;
+  }
+  100% {
+    width: ${dailyHourCoverGraphLength}%;
+  }
+`;
+  }, [dailyHours]);
   const isNoTask = useMemo(() => taskList.length === 0, [taskList.length]);
 
   return {
     /** 日付のstring(YYYY/MM/DD) */
     dateString,
-    /** 稼働時間の灰色の空白部分のグラフの長さ(%) 稼働時間の反対なので、0%=10h 100%=0h */
-    dailyHourCoverGraphLength,
+    /** 稼働時間のグラフのアニメーション */
+    growAnimation,
     /** タスクがないかどうか */
     isNoTask,
   };


### PR DESCRIPTION
タイトル通り

# 詳細
## メソッド概要
- @keyframesで作成していたアニメーションを Keyframesに変更
  - @keyframesで作成した場合 - グローバルCSS化する <=別ページで共有されてしまう場合がある
    - 実際にページ遷移時に過去のデータが利用される場合あり
  - Keyframesで作成した場合.- ページごとに個別化 -> 別ページで共有される心配はなくなる
## メソッド詳しく
- @keyframes 以下をmemo化して切り取り
  - keyframesでオブジェクト化してメモ化
    - keyframesでメモ化してるので長さは内部で宣言させて個別のメモ化は解除
  - animationにkeyframesを適応