### PR TITLE
テーブルの高さを調整+ヘッダー固定

### DIFF
--- a/my-app/src/app/work-log/task/table/TaskSummaryTable.tsx
+++ b/my-app/src/app/work-log/task/table/TaskSummaryTable.tsx
@@ -42,8 +42,8 @@ export default function TaskSummaryTable({
     doFilterByFilterList,
   } = TaskSummaryTableLogic({ taskList });
   return (
-    <TableContainer>
-      <Table sx={{ tableLayout: "fixed" }}>
+    <TableContainer sx={{ height: `calc(100vh - 180px)` }}>
+      <Table sx={{ tableLayout: "fixed" }} stickyHeader>
         <TableHead>
           <TaskSummaryTableHeader
             isFavoriteChecked={isFavoriteChecked}


### PR DESCRIPTION
タイトル通り

# 詳細
- TaskSummaryPageのテーブルのUI調整
  - スクロールしない大きさに調整
  - ヘッダーを固定化