### PR TITLE
タグが非選択の場合の処理を修正

### DIFF
--- a/my-app/src/lib/services/memoService.ts
+++ b/my-app/src/lib/services/memoService.ts
@@ -52,13 +52,15 @@ export const updateMemo = async (
   text?: string,
   tagId?: number
 ) => {
+  // tagIdが0の場合はnullに変換する(memoのtagIdはNull許容 かつtagId0の場合は未選択の場合なので)
+  const nullableTagId = tagId === 0 ? null : tagId;
   const data = await prisma.memo.update({
     where: { id },
     data: {
       // あるデータだけ更新 (左辺falseだと処理なし)
       ...(title !== undefined && { title }),
       ...(text !== undefined && { text }),
-      ...(tagId !== undefined && { tagId }),
+      ...(tagId !== undefined && { nullableTagId }),
     },
     select: { id: true },
   });


### PR DESCRIPTION
タイトル通り

# 詳細
- メモの更新時にタグが非選択時の処理を修正
  - tagId:0が与えられた場合を非選択とする(FEでtagId:0で非選択として与えているので)
  - 0である場合に0 -> nullに変換する
  - dbのmemo側のtagIdはNullableなのでnull与えて問題なし
    - むしろrelation切れるので期待した動作になる