### PR TITLE
Feature/add complete confirm dialog to task summary page

### DIFF
--- a/my-app/src/app/work-log/task/page.tsx
+++ b/my-app/src/app/work-log/task/page.tsx
@@ -12,25 +12,27 @@ import CompleteConfirmDialog from "@/component/dialog/complete-confirm/CompleteC
  */
 export default function TaskSummaryPage() {
   const {
+    open: openComplete,
+    onClose: onCloseComplete,
+    onOpen: onOpenComplete,
+  } = useDialog();
+  const {
     taskSummaryData,
     isLoading,
     isValidating,
     rowRefs,
     handleSaveAll,
     handleResetAll,
+    handleConfirmComplete,
     onDirtyChange,
     isDirty,
     selectedItemId,
     handleSelectItem,
     isAnyItemSelected,
     navigateToDetail,
-  } = useTaskSummaryPage();
+  } = useTaskSummaryPage({ onOpenComplete });
   const { open, onClose, onOpen } = useDialog();
-  const {
-    open: openComplete,
-    onClose: onCloseComplete,
-    onOpen: onOpenComplete,
-  } = useDialog();
+
   return (
     <>
       <TaskSummaryHeader
@@ -55,7 +57,7 @@ export default function TaskSummaryPage() {
         <CompleteConfirmDialog
           open={openComplete}
           onClose={onCloseComplete}
-          onAccept={() => {}} // TODO: あとで修正
+          onAccept={handleConfirmComplete}
         />
       )}
     </>

--- a/my-app/src/app/work-log/task/useTaskSummaryPage.ts
+++ b/my-app/src/app/work-log/task/useTaskSummaryPage.ts
@@ -15,10 +15,15 @@ import { TaskSummary } from "@/type/Task";
 import { mutate } from "swr";
 import { getTaskSummaryQuery } from "@/lib/query";
 
+type Props = {
+  /** 完了確認ダイアログ開くハンドラー */
+  onOpenComplete: () => void;
+};
+
 /**
  * タスク一覧ページのパラメータ関連
  */
-export default function useTaskSummaryPage() {
+export default function useTaskSummaryPage({ onOpenComplete }: Props) {
   const router = useRouter();
   const params = useSearchParams();
   const query = useMemo(() => getTaskSummaryQuery(params), [params]);
@@ -76,6 +81,10 @@ export default function useTaskSummaryPage() {
     }
   }, [getInitialRef, taskSummaryData]);
 
+  // 送信データ
+  const sendData = useRef<
+    { id: number; progress?: number; isFavorite?: boolean }[] | null
+  >(null);
   // 変更のある対象のキーを取得する関数
   const getTargetKeys = useCallback(() => {
     const keys = Object.keys(rowRefs.current);
@@ -101,8 +110,22 @@ export default function useTaskSummaryPage() {
       const data = ref.current?.getFormData();
       result.push({ id: Number(key), ...data }); // 判別ようにidを付与
     }
-    updateAll(result);
-  }, [getTargetKeys, updateAll]);
+    // いずれかのデータの進捗が100%になる場合はダイアログ表示
+    const isAnyCompleted = result.some((v) => v.progress === 100);
+    if (isAnyCompleted) {
+      sendData.current = result; // refに送信データを一時保存
+      onOpenComplete();
+    } else {
+      updateAll(result);
+    }
+  }, [getTargetKeys, onOpenComplete, updateAll]);
+
+  const handleConfirmComplete = useCallback(async () => {
+    if (sendData.current) {
+      await updateAll(sendData.current);
+      sendData.current = null;
+    }
+  }, [updateAll]);
 
   const handleResetAll = useCallback(() => {
     const targetKeys = getTargetKeys();
@@ -146,6 +169,8 @@ export default function useTaskSummaryPage() {
     handleSaveAll,
     /** まとめてリセットを行う関数 */
     handleResetAll,
+    /** 完了確認時のハンドラー(データ保存を行う) */
+    handleConfirmComplete,
     /** 選択中のアイテムid */
     selectedItemId,
     /** アイテム選択時のハンドラー */


### PR DESCRIPTION
# 変更点
- タスク一覧ページで進捗を100%に変更する際に確認ダイアログを表示するように変更

# 詳細
- データの送信処理をupdateAllとして分離
- Array.someでデータ送信前にprogress===100となる項目が含まれているかチェック
  - 含まれない場合はそのままupdateAllで保存処理
  - 含まれる場合はref値sendDataでresultを保存した後にダイアログを呼び出し
- ダイアログでaccept時のハンドラーを作成
  - ref値からsendData.currentを読み取り、updateAllで保存させる
  - 一応ref値はnullにしとく(実際はやんなくても問題ないはずだけど)