### PR TITLE
"@"でグローバル化してたアニメーションをコンポーネントごとにローカル化

### DIFF
--- a/my-app/src/app/work-log/task/[id]/main-display/MainDisplay.tsx
+++ b/my-app/src/app/work-log/task/[id]/main-display/MainDisplay.tsx
@@ -31,7 +31,7 @@ export default function MainDisplay({
   totalHours,
   onClickNavigateCategoryPage,
 }: Props) {
-  const { progressGrayBarWidth } = MainDisplayLogic({ progress });
+  const { growAnimation } = MainDisplayLogic({ progress });
   return (
     <Stack spacing={0.5}>
       {/** タスク/ おきにいり */}
@@ -75,13 +75,7 @@ export default function MainDisplay({
               height: "100%",
               width: "0%",
               backgroundColor: "#eee",
-              animation: "grow 1s ease-out forwards",
-              "@keyframes grow": {
-                "0%": { width: "100%" },
-                "100%": {
-                  width: `${progressGrayBarWidth}%`,
-                },
-              },
+              animation: `${growAnimation} 1s ease-out forwards`,
             }}
           />
         </Stack>

--- a/my-app/src/app/work-log/task/[id]/main-display/MainDisplayLogic.ts
+++ b/my-app/src/app/work-log/task/[id]/main-display/MainDisplayLogic.ts
@@ -1,3 +1,4 @@
+import { keyframes } from "@emotion/react";
 import { useMemo } from "react";
 
 type Props = {
@@ -9,10 +10,20 @@ type Props = {
  * タスク詳細ページのメイン部分の表示のロジック
  */
 export default function MainDisplayLogic({ progress }: Props) {
-  const progressGrayBarWidth = useMemo(() => 100 - progress, [progress]);
+  const growAnimation = useMemo(() => {
+    const dailyHourCoverGraphLength = 100 - progress;
+    return keyframes`
+   0% {
+     width: 100%;
+   }
+   100% {
+     width: ${dailyHourCoverGraphLength}%;
+   }
+ `;
+  }, [progress]);
 
   return {
     /** 進行度のバーの灰色部分の長さ */
-    progressGrayBarWidth,
+    growAnimation,
   };
 }


### PR DESCRIPTION
タイトル通り

# 詳細
- 進捗のバーがページ移動時に表示と値が一致しないことのある問題を修正
  - グローバルにアニメーションを登録していたことによって前回のアニメーションが引き継がれていることがあったのが問題
  - グローバル -> ローカルに変更して対処