### PR TITLE
タスクの選択賜に完了済みのタスクを含まないように変更

### DIFF
--- a/my-app/src/lib/services/taskService.ts
+++ b/my-app/src/lib/services/taskService.ts
@@ -11,7 +11,10 @@ import prisma from "../prisma";
  */
 export const getTaskOptions = async (categoryId: number) => {
   const data: TaskOption[] = await prisma.task.findMany({
-    where: { categoryId: categoryId },
+    where: {
+      categoryId: categoryId,
+      progress: { not: 100 /** 完了済みは取得しない */ },
+    },
     select: { id: true, name: true },
   });
   return data;


### PR DESCRIPTION
タイトル通り

# 詳細
- タスクを選択する場合の選択賜に完了済みを含まないように変更
  - progress:100の場合にprismaでwhere notで除外するように設定