### PR TITLE
カテゴリ選択を取得するロジック追記

### DIFF
--- a/my-app/src/app/work-log/category/category-select/CategorySelectLogic.ts
+++ b/my-app/src/app/work-log/category/category-select/CategorySelectLogic.ts
@@ -1,17 +1,15 @@
+import apiClient from "@/lib/apiClient";
 import { CategoryOption } from "@/type/Category";
+import useAspidaSWR from "@aspida/swr";
 
 /**
  * カテゴリページのカテゴリ選択部分のロジック
  */
 export default function CategorySelectLogic() {
-  // TODO:データフェッチさせる
-
-  const categoryOptions: CategoryOption[] = [
-    { id: 1, name: "カテゴリ1" },
-    { id: 2, name: "カテゴリ2" },
-    { id: 3, name: "カテゴリ3" },
-    { id: 4, name: "カテゴリ4" },
-  ];
+  const { data } = useAspidaSWR(apiClient.work_log.categories.options, "get", {
+    key: "api/work-log/categories/options",
+  });
+  const categoryOptions: CategoryOption[] = data?.body ?? [];
   return {
     /** カテゴリの選択賜一覧 */
     categoryOptions,


### PR DESCRIPTION
# 変更点
- 既存のカテゴリー一覧を取得するロジックを適応

# 詳細
- 既存のcategories/options のエンドポイントからカテゴリ一覧を取得できるように変更