### PR TITLE
稼働ないデータを除外する処理を追加

### DIFF
--- a/my-app/src/lib/services/categoryService.ts
+++ b/my-app/src/lib/services/categoryService.ts
@@ -76,18 +76,21 @@ export const getCategoryActivity = async (
                 lte: lastDate,
               },
             }),
+          workTime: { not: 0 }, // 稼働のないデータを含めない
         },
         select: { workTime: true },
       },
     },
   });
-  const result: CategoryTaskActivity[] = data.map((v) => {
-    const totalHours = v.tasks.reduce((a, b) => b.workTime + a, 0);
-    return {
-      taskName: v.name,
-      totalHours: totalHours,
-    };
-  });
+  const result: CategoryTaskActivity[] = data
+    .filter((v) => v.tasks.length !== 0) // 稼働データのないタスクは除外
+    .map((v) => {
+      const totalHours = v.tasks.reduce((a, b) => b.workTime + a, 0);
+      return {
+        taskName: v.name,
+        totalHours: totalHours,
+      };
+    });
   return result;
 };
 


### PR DESCRIPTION
タイトル通り

# 詳細
- カテゴリの稼働グラフについて
  - DBからデータを取得する際にworkTime:0のデータをwhere notで取らないように修正
  - データ取得後に整形前にtasksが空のタスクをfilterで除外するように修正