### PR TITLE
UI/main page list loading no task UI

### DIFF
--- a/my-app/src/app/work-log/component/table/TaskTable.tsx
+++ b/my-app/src/app/work-log/component/table/TaskTable.tsx
@@ -13,12 +13,13 @@ import { memo } from "react";
 import DoubleArrowIcon from "@mui/icons-material/DoubleArrow";
 import TaskTableLogic from "./TaskTableLogic";
 import TableBodyNoItem from "@/component/table/body/TableBodyNoItem/TableBodyNoItem";
+import TableBodyLoading from "@/component/table/body/TableBodyLoading/TableBodyLoading";
 
 /**
  * メインページのタスクテーブルコンポーネント
  */
 const TaskTable = memo(function TaskTable() {
-  const { data, navigateToDetail } = TaskTableLogic();
+  const { data, isLoading, navigateToDetail } = TaskTableLogic();
   return (
     <>
       <Typography textAlign={"center"} variant="h6" color="text.secondary">
@@ -43,8 +44,12 @@ const TaskTable = memo(function TaskTable() {
           </TableHead>
           {/** ボディ */}
           <TableBody>
-            {data.length === 0 && <TableBodyNoItem colCount={3} />}
-            {data.length !== 0 &&
+            {isLoading && <TableBodyLoading colCount={3} />}
+            {!isLoading && data.length === 0 && (
+              <TableBodyNoItem colCount={3} />
+            )}
+            {!isLoading &&
+              data.length !== 0 &&
               data.map((item) => (
                 <TableRow key={item.id}>
                   {/** タスク名 */}

--- a/my-app/src/app/work-log/component/table/TaskTableLogic.ts
+++ b/my-app/src/app/work-log/component/table/TaskTableLogic.ts
@@ -7,7 +7,7 @@ import { useCallback } from "react";
  * メインページのタスクテーブルコンポーネントのロジック
  */
 export default function TaskTableLogic() {
-  const { data: rawData } = useAspidaSWR(
+  const { data: rawData, isLoading } = useAspidaSWR(
     apiClient.work_log.tasks.progress.last_month,
     "get",
     { key: "api/work-log/tasks/progress/last-month" }
@@ -22,6 +22,8 @@ export default function TaskTableLogic() {
   return {
     /** 表示するデータ */
     data,
+    /** データのロード状態 */
+    isLoading,
     /** タスク詳細ページへ飛ぶハンドラー */
     navigateToDetail,
   };


### PR DESCRIPTION
# 変更点
- タスクテーブルのロード時/タスクない時のUIを追加

# 詳細
- 既存のUIを適応してロード状態/タスク無しのUIを追加