### PR TITLE
既存のUIでタスクがない場合に対応

### DIFF
--- a/my-app/src/app/work-log/component/pie-chart/MainPagePieChart.tsx
+++ b/my-app/src/app/work-log/component/pie-chart/MainPagePieChart.tsx
@@ -5,6 +5,7 @@ import { Pie, PieChart, Tooltip } from "recharts";
 import MainPagePieChartLogic from "./MainPagePieChartLogic";
 import CustomToolTipWrapper from "@/component/graph/tool-chip/CustomToolTipWrapper";
 import CustomToolTipContent from "@/component/graph/tool-chip/CustomToolTipContent";
+import NoDataPieGraph from "@/component/graph/NoDataPie";
 
 /**
  * メインページの円グラフ
@@ -16,31 +17,36 @@ const MainPagePieChart = memo(function MainPagePieChart() {
       <Typography variant="h6" mb={2} color="text.secondary">
         過去一ヶ月のタスク稼働
       </Typography>
-      <PieChart width={400} height={300}>
-        <Pie
-          data={data}
-          dataKey="value"
-          cx="50%"
-          cy="50%"
-          outerRadius={150}
-          fill="#8884d8"
-        />
-        <Tooltip
-          content={
-            <CustomToolTipWrapper>
-              {(dataItem: (typeof data)[0]) =>
-                dataItem.task.map((item, idx) => (
-                  <CustomToolTipContent
-                    key={idx}
-                    name={item.name}
-                    value={item.hours}
-                  />
-                ))
-              }
-            </CustomToolTipWrapper>
-          }
-        />
-      </PieChart>
+      {data.length === 0 && (
+        <NoDataPieGraph width={400} height={300} radius={150} />
+      )}
+      {data.length !== 0 && (
+        <PieChart width={400} height={300}>
+          <Pie
+            data={data}
+            dataKey="value"
+            cx="50%"
+            cy="50%"
+            outerRadius={150}
+            fill="#8884d8"
+          />
+          <Tooltip
+            content={
+              <CustomToolTipWrapper>
+                {(dataItem: (typeof data)[0]) =>
+                  dataItem.task.map((item, idx) => (
+                    <CustomToolTipContent
+                      key={idx}
+                      name={item.name}
+                      value={item.hours}
+                    />
+                  ))
+                }
+              </CustomToolTipWrapper>
+            }
+          />
+        </PieChart>
+      )}
     </Stack>
   );
 });


### PR DESCRIPTION
タイトル通り

# 詳細
- メインページで最近の稼働がない場合に表示する用のUIを追加