### PR TITLE
Feature/add memo edit dialog reset button

### DIFF
--- a/my-app/src/component/dialog/memo-edit-dialog/MemoEditDialog.tsx
+++ b/my-app/src/component/dialog/memo-edit-dialog/MemoEditDialog.tsx
@@ -49,6 +49,7 @@ export default function MemoEditDialog({
     isLoading,
     isSending,
     handleEdit,
+    handleReset,
     handleDelete,
     onSubmit,
   } = MemoEditDialogLogic({
@@ -120,7 +121,7 @@ export default function MemoEditDialog({
                 {/** 編集中かどうかで保存/編集ボタン 削除/リセットボタン を切り替え */}
                 {isEdit && (
                   <>
-                    <IconButton onClick={() => {}} color="error">
+                    <IconButton onClick={handleReset} color="error">
                       <RestartAltIcon />
                     </IconButton>
                     <IconButton

--- a/my-app/src/component/dialog/memo-edit-dialog/MemoEditDialogLogic.tsx
+++ b/my-app/src/component/dialog/memo-edit-dialog/MemoEditDialogLogic.tsx
@@ -76,7 +76,7 @@ export default function MemoEditDialogLogic({
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [isSending, setIsSending] = useState<boolean>(false);
   // RHF
-  const { control, handleSubmit, setValue } = useForm<SubmitData>({
+  const { control, handleSubmit, setValue, reset } = useForm<SubmitData>({
     defaultValues: { text: "", tagId: 0, title: title },
   });
   // ロード完了時にsetValueで初期値をセットする
@@ -110,6 +110,10 @@ export default function MemoEditDialogLogic({
     },
     [id, taskId]
   );
+  const handleReset = useCallback(() => {
+    reset(init.current);
+    setIsEdit(false);
+  }, [reset]);
 
   const handleDelete = useCallback(async () => {
     await apiClient.work_log.memos._id(id).delete();
@@ -133,6 +137,8 @@ export default function MemoEditDialogLogic({
     onSubmit: handleSubmit(onSubmit),
     /** 編集状態に入るときのハンドラー */
     handleEdit,
+    /** リセット時のハンドラー */
+    handleReset,
     /** 削除時のハンドラー */
     handleDelete,
   };


### PR DESCRIPTION
# 変更点
- メモ編集中にリセットボタンを表示するように変更

# 詳細
- メモ編集時に削除ボタン -> リセットボタンに表示を変更
- リセット時のハンドラー作成
  - RHFのresetでinit.currentの値に初期化後に編集状態を解除
