### PR TITLE
UI/update daily summary date dialog no task found logic

### DIFF
--- a/my-app/src/app/work-log/daily/dialog/DateDialog.tsx
+++ b/my-app/src/app/work-log/daily/dialog/DateDialog.tsx
@@ -152,6 +152,16 @@ export default function DateDialog({
             <CircularProgress size={25} />
           </Stack>
         )}
+        {!isLoading && dateDetails === null && (
+          <Stack
+            height="45%"
+            direction="row"
+            alignItems={"center"}
+            justifyContent={"center"}
+          >
+            <Typography variant="subtitle2">データがありません</Typography>
+          </Stack>
+        )}
         {!isLoading && dateDetails && (
           <Stack height="45%" direction="row">
             {/** 左下 */}


### PR DESCRIPTION
# 変更点
- DateDialogのタスクない場合とロード中のuiを調整

# 詳細
- ダイアログ内の各パーツの分離方法変更
  - 上(ラジオボタン/セレクトの日付指定)/下(データ表示/ナビボタン)-> 上(同様)/データ表示/ボタン の3箇所に変更
  - これに伴って位置調整
- ロード/データなしの場合の分岐について
  - メモ/タスクそれぞれに適応してたのをデータ全体に適応する形式に変更
  - ロード/データなしの表示自体も全体に適応されるように変更
- ボタンの状態管理
  - ロード状態でdisabledになるように変更

# 注意点
- データがない場合について
  - 「一度でも詳細ページを開いた場合」この時にデータが作成されるが、タスクを追加してない場合は空データだが、データがある判定になってる
  - そのため、空なのにデータがある分岐に入ってしまう場合がある

上記の問題についてはBEで判定させる -> dbから取得時にタスクがなければnullを返させる