### PR TITLE
UI/update category page new design

### DIFF
--- a/my-app/src/app/work-log/category/page.tsx
+++ b/my-app/src/app/work-log/category/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CircularProgress, Stack } from "@mui/material";
+import { CircularProgress, Divider, Stack } from "@mui/material";
 import CategorySelect from "./category-select/CategorySelect";
 const TaskActivityPieChart = dynamic(
   () => import("./task-activity-pie-chart/TaskActivityPieChart"),
@@ -28,15 +28,16 @@ export default function CategoryPage() {
   return (
     <Stack>
       {/** 上部 */}
-      <Stack direction="row" justifyContent={"space-between"}>
+      <Stack direction="row" p={4} justifyContent={"space-between"}>
         <Stack>カテゴリ関連の情報</Stack>
         <Stack>
           <CategorySelect />
           <div>完了ボタン的な</div>
         </Stack>
       </Stack>
+      <Divider sx={{ width: "95%", alignSelf: "center" }} />
       {/** 下部 */}
-      <Stack direction="row" p={4}>
+      <Stack direction="row" px={4}>
         {/** 下左側(期間グラフ) */}
         <Stack width="50%" justifyContent={"space-around"}>
           <TaskActivityPieChart />


### PR DESCRIPTION
# 変更点
- カテゴリページのデザインを更新

# 詳細
- 配置デザインの変更
  - 上部にカテゴリ情報やカテゴリの変更などを配置
    - カテゴリの選択は左上 -> 右上に移動
  - dividerで上部/下部を区切り
  - 下部は今までのグラフとテーブルを表示

# 補足
- 上部デザインについて
  - まとめて１つのコンポーネントとして分離する予定
  - 現在のカテゴリ選択のコンポーネントを名称変更して一つのコンポーネントとして利用する予定