### PR TITLE
UI/update category header normal display

### DIFF
--- a/my-app/src/app/work-log/category/category-header/CategoryHeader.tsx
+++ b/my-app/src/app/work-log/category/category-header/CategoryHeader.tsx
@@ -1,15 +1,15 @@
 "use client";
 import {
-  Button,
   FormControl,
   FormLabel,
+  IconButton,
   keyframes,
   MenuItem,
   Select,
   Stack,
   Typography,
 } from "@mui/material";
-import DoneIcon from "@mui/icons-material/Done";
+import MenuIcon from "@mui/icons-material/Menu";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CategoryHeaderLogic from "./CategoryHeaderLogic";
 
@@ -79,7 +79,7 @@ export default function CategoryHeader() {
         </Stack>
       </Stack>
       {/** 右部分(カテゴリ選択/完了ボタン) */}
-      <Stack spacing={1}>
+      <Stack spacing={1} direction="row">
         <FormControl>
           <FormLabel>カテゴリを選択</FormLabel>
           <Select
@@ -97,9 +97,9 @@ export default function CategoryHeader() {
             ))}
           </Select>
         </FormControl>
-        <Button startIcon={<DoneIcon />} variant="outlined" color="success">
-          完了する
-        </Button>
+        <IconButton sx={{ width: 40, height: 40, alignSelf: "center" }}>
+          <MenuIcon />
+        </IconButton>
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
# 変更点
- カテゴリーページのヘッダーの基本UI作成

# 詳細
- 左部分(データ表示)
  - typoで３行で表示
  - 1行目にはカテゴリ名と完了状態であればその旨を表示(現状はフラグ管理がないので常時表示)
  - 2行目には稼働時間とグラフを表示
  - 3行目には開始~最終稼働の日付を表示
- 右部分(操作関連)
  - カテゴリ選択のセレクトを左側に配置(元々配置していたもの)
    - ラベルはin-labelになるように変更
  - その他のアクション関連を格納するボタンを右側に配置
    - 現状は対象がないのでボタンが置いてあるだけ