### PR TITLE
Fix/category header select out of range error

### DIFF
--- a/my-app/src/app/work-log/category/category-header/CategoryHeader.tsx
+++ b/my-app/src/app/work-log/category/category-header/CategoryHeader.tsx
@@ -28,6 +28,7 @@ export default function CategoryHeader() {
     categoryOptions,
     isLoadingOptions,
     selectedCategoryId,
+    isSelectedIdAvailable,
     selectedCategoryName,
     isLoadingCategorySummary,
     isCompleted,
@@ -130,7 +131,7 @@ export default function CategoryHeader() {
         )}
         {/** 右部分(カテゴリ選択/完了ボタン) */}
         <Stack spacing={1} direction="row">
-          {isLoadingOptions && (
+          {(isLoadingOptions || !isSelectedIdAvailable) && (
             <Stack
               width={113}
               height={104}
@@ -140,7 +141,7 @@ export default function CategoryHeader() {
               <CircularProgress size={30} />
             </Stack>
           )}
-          {!isLoadingOptions && (
+          {!isLoadingOptions && isSelectedIdAvailable && (
             <FormControl>
               <FormLabel>カテゴリを選択</FormLabel>
               <Select

--- a/my-app/src/app/work-log/category/category-header/CategoryHeaderLogic.ts
+++ b/my-app/src/app/work-log/category/category-header/CategoryHeaderLogic.ts
@@ -99,7 +99,10 @@ export default function CategoryHeaderLogic() {
       router.replace(`?id=${categoryOptions[0].id}`);
     }
   }, [categoryOptions, optionsQuery, router]);
-
+  const isSelectedIdAvailable = useMemo(
+    () => categoryOptions.some((v) => v.id === selectedCategoryId),
+    [categoryOptions, selectedCategoryId]
+  );
   const { data: rawCategorySummaryData, isLoading: isLoadingCategorySummary } =
     useAspidaSWR(
       apiClient.work_log.categories._id(selectedCategoryId).summary,
@@ -165,6 +168,8 @@ export default function CategoryHeaderLogic() {
     isLoadingOptions,
     /** 選択中のカテゴリid */
     selectedCategoryId,
+    /** 選択中のカテゴリidが存在するか */
+    isSelectedIdAvailable,
     /** カテゴリの概要のロード状態 */
     isLoadingCategorySummary,
     /** 選択中のカテゴリ名 */


### PR DESCRIPTION
# 変更点
- カテゴリーのセレクトが範囲外になるエラーを解消

# 詳細
- 初期フェッチ時
  - SWRのisLoadingによって描画しないように変更
- 表示範囲変更時
  - useEffectでクエリ変更してデータフェッチ後に、表示範囲内の先頭データを表示するように変更
    - 現在はid順でとってるのでidが若いものを表示
- 再検証開始 -> 終了時
  - Array.someで検証し、一致するデータがない場合はロード中と同じ扱いにすることで対処

# その他修正/変更予定
- カテゴリ一覧データフェッチ関連
  - クエリがある場合は更新日順に取ってくるように変更する予定
    - 表示範囲の設定が更新日依存のため、更新が新しい順の方が都合がいいため
  - 更新日の条件設定がバグってるので修正
    - prismaのsomeで「全てのデータの更新日から含まれるか」となってるため、最終更新日が範囲外のものも取れてしまってる問題