### PR TITLE
タスク追加時にカテゴリ選択賜から完了済みをデフォで除くように変更

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/menu/dialog/TaskAddDialog/TaskAddDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/menu/dialog/TaskAddDialog/TaskAddDialogLogic.ts
@@ -27,7 +27,10 @@ export default function TaskAddDialogLogic({ onClose }: Props) {
   const { data: categoryData, isLoading: isLoadingCategory } = useAspidaSWR(
     apiClient.work_log.categories.options,
     "get",
-    { key: ["api/work-log/categories/options"] }
+    {
+      query: { displayRange: "all", hideCompleted: "true" },
+      key: ["api/work-log/categories/options"],
+    }
   );
   const categoryList = categoryData?.body;
   const { data: taskData, isLoading: isLoadingTask } = useAspidaSWR(

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -44,7 +44,10 @@ export default function TaskEditDialogLogic({
   const { data: categoryData, isLoading: isLoadingCategory } = useAspidaSWR(
     apiClient.work_log.categories.options,
     "get",
-    { key: ["api/work-log/categories/options"] }
+    {
+      query: { displayRange: "all", hideCompleted: "true" },
+      key: ["api/work-log/categories/options"],
+    }
   );
   const categoryList = categoryData?.body;
   const { data: taskData, isLoading: isLoadingTask } = useAspidaSWR(

--- a/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialogLogic.ts
@@ -38,7 +38,10 @@ export default function TaskEditDialogLogic({
   const { data, isLoading } = useAspidaSWR(
     apiClient.work_log.categories.options,
     "get",
-    { key: ["api/work-log/categories/options"] }
+    {
+      query: { displayRange: "all", hideCompleted: "true" },
+      key: ["api/work-log/categories/options"],
+    }
   );
   const categoryList: CategoryOption[] = data?.body ?? [];
 

--- a/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
+++ b/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
@@ -45,6 +45,7 @@ export default function CreateTaskDialogLogic({
   );
   // TODO:でーたふぇっちさせる
   const { data } = useAspidaSWR(apiClient.work_log.categories.options, "get", {
+    query: { displayRange: "all", hideCompleted: "true" },
     key: ["api/work-log/categories/options"],
   });
   const categoryList = data?.body;


### PR DESCRIPTION
# 変更点
- カテゴリ選択を取得する際に完了済みのカテゴリを非表示に変更

# 詳細
- タスク追加/編集時のカテゴリ選択時の選択賜の取得時のクエリを追加
  - displayRange:"all",hideCompleted:"true"を与えて完了済みの値を選択できないように変更
  - keyはとりあえず第二なしで