### PR TITLE
Feature/update main page task activity logic exclude 0 hours

### DIFF
--- a/my-app/src/lib/services/taskService.ts
+++ b/my-app/src/lib/services/taskService.ts
@@ -286,7 +286,7 @@ export const getLastMonthTaskActivities = async () => {
       task: filteredTask,
     };
   });
-  return result;
+  return result.filter((v) => v.value !== 0);
 };
 
 /**


### PR DESCRIPTION
# 変更点
- タスク稼働の円グラフデータに0時間のタスクを含まないように変更
- 同様にカテゴリ内のタスク稼働の合計が0時間のカテゴリをデータに含まないように変更

# 詳細
- タスクデータ整形後、稼働時間が0の場合をArray.fillterで除外
- タスク送信前にvalue(カテゴリ時間/総稼働時間)の値が0の場合Array.fillterで除外