### PR TITLE
Feature/task detail work calendar nav

### DIFF
--- a/my-app/src/app/work-log/task/[id]/work-calendar/nav/WorkCalendarNav.stories.tsx
+++ b/my-app/src/app/work-log/task/[id]/work-calendar/nav/WorkCalendarNav.stories.tsx
@@ -1,15 +1,21 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import WorkCalendarNav from './WorkCalendarNav';
+import WorkCalendarNav from "./WorkCalendarNav";
 
 const meta = {
   component: WorkCalendarNav,
+  args: {
+    currentYear: 2025,
+    currentMonth: 4,
+    onPrevMonth: () => {},
+    onNextMonth: () => {},
+    isMinMonth: false,
+    isMaxMonth: false,
+  },
 } satisfies Meta<typeof WorkCalendarNav>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {}
-};
+export const Default: Story = {};

--- a/my-app/src/app/work-log/task/[id]/work-calendar/nav/WorkCalendarNav.tsx
+++ b/my-app/src/app/work-log/task/[id]/work-calendar/nav/WorkCalendarNav.tsx
@@ -3,12 +3,32 @@ import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { memo } from "react";
 
+type Props = {
+  /** 現在表示している年 */
+  currentYear: number;
+  /** 現在表示している月（1〜12） */
+  currentMonth: number;
+  /** 前の月へ移動するハンドラー */
+  onPrevMonth: () => void;
+  /** 次の月へ移動するハンドラー */
+  onNextMonth: () => void;
+  /** 最も過去の月に到達しているか（戻るボタンの無効化用） */
+  isMinMonth: boolean;
+  /** 最も未来の月に到達しているか（進むボタンの無効化用） */
+  isMaxMonth: boolean;
+};
+
 /**
  * 稼働のカレンダーのナビゲーション部分
  */
-const WorkCalendarNav = memo(function WorkCalendarNav() {
-  const year = 2025;
-  const month = 4;
+const WorkCalendarNav = memo(function WorkCalendarNav({
+  currentYear,
+  currentMonth,
+  onPrevMonth,
+  onNextMonth,
+  isMinMonth,
+  isMaxMonth,
+}: Props) {
   return (
     <Stack direction="row" spacing={3} alignItems={"center"}>
       {/** 戻る方のナビゲーション */}
@@ -22,12 +42,14 @@ const WorkCalendarNav = memo(function WorkCalendarNav() {
             transform: "scale(1.1) translateX(-6px)",
           },
         }}
+        onClick={onPrevMonth}
+        disabled={isMinMonth}
       >
         <NavigateBeforeIcon />
       </IconButton>
       {/** 表示中の年月について */}
       <Typography>
-        {year} 年 {month} 月
+        {currentYear} 年 {currentMonth} 月
       </Typography>
       {/** 進む方のナビゲーション */}
       <IconButton
@@ -40,6 +62,8 @@ const WorkCalendarNav = memo(function WorkCalendarNav() {
             transform: "scale(1.1) translateX(6px)",
           },
         }}
+        onClick={onNextMonth}
+        disabled={isMaxMonth}
       >
         <NavigateNextIcon />
       </IconButton>


### PR DESCRIPTION
# 変更点
- タスク詳細のカレンダー上部のナビゲーションのコンポーネントを作成

# 詳細
- 現在表示中の年月を中心に、左右にナビゲーションようのアイコンボタンを配置
  - アイコンボタンにホバー時/クリック時にそれぞれcssアニメーションで移動
- 範囲外に移動しないように最後の範囲であればdisabledになるように設定
- 親からデータ及びハンドラー/最後の範囲かどうかの判定を引数で受け取り