### PR TITLE
タスク追加時にカテゴリのタスク一覧のデータも再検証させることで即時反映させる

### DIFF
--- a/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
+++ b/my-app/src/component/dialog/CreateTaskDialog/CreateTaskDialogLogic.ts
@@ -60,6 +60,7 @@ export default function CreateTaskDialogLogic({
           },
         });
         mutate(`api/work-log/tasks/options?categoryId=${data.categoryId}`);
+        mutate(`api/work-log/categories/${categoryId}/tasks`); // 追加先のカテゴリのタスクも再検証する
         onCreateTask?.(res.body.id);
         onClose();
       } catch (error) {
@@ -71,7 +72,7 @@ export default function CreateTaskDialogLogic({
         }
       }
     },
-    [onClose, onCreateTask]
+    [categoryId, onClose, onCreateTask]
   );
 
   return {


### PR DESCRIPTION
タイトル通り

# 詳細
- タスク追加ダイアログ
  - 追加後にカテゴリのタスク一覧の表示の部分もmutateで更新させる
  - カテゴリページでタスク追加時に即時反映できるように