### PR TITLE
日付の一覧データのキャッシュキーを明示的に宣言して、クエリがない場合と現在の年月がクエリに選択されている場合に同じキャッシュを利用させるよ…

### DIFF
--- a/my-app/src/app/work-log/daily/fetchLogic.ts
+++ b/my-app/src/app/work-log/daily/fetchLogic.ts
@@ -2,6 +2,7 @@ import useAspidaSWR from "@aspida/swr";
 import apiClient from "@/lib/apiClient";
 import { useSearchParams } from "next/navigation";
 import { DateSummary } from "@/type/Date";
+import { getTodayMonth, getTodayYear } from "@/lib/date";
 
 /**
  * DailyPageのフェッチ関連のロジック
@@ -11,10 +12,17 @@ export default function DailyPageFetchLogic() {
   const year = searchParams.get("year") ?? undefined;
   const month = searchParams.get("month") ?? undefined;
 
+  // key用のクエリの初期値(undefined時は現在の日付のデータを返すようになってるので)
+  const _year = year ?? getTodayYear();
+  const _month = month ?? getTodayMonth();
+
   const { data, isLoading: isLoadingItemList } = useAspidaSWR(
     apiClient.work_log.daily.summary,
     "get",
-    { query: { year, month } }
+    {
+      query: { year, month },
+      key: ["api/work-log/daily/summary", `year=${_year}&month=${_month}`],
+    }
   );
   const rawItemList = data?.body ?? [];
   const itemList: DateSummary[] = rawItemList.map((v) => {


### PR DESCRIPTION
…うにする

ほぼタイトル通り
クエリの無い場合は現在の年月のデータをとってきてる
ので、クエリがない場合とyearとmonthが現在の年月である場合のkeyを同等に設定