### PR TITLE
Feature/add progress change bar to daily detail task edit dialog

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.stories.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     initialTaskId: 1,
     initialCategoryId: 1,
     initialHours: 8,
+    initProgressRange: 50,
     open: true,
     onClose: () => {},
   },

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -35,6 +35,8 @@ type Props = {
   open: boolean;
   /** 稼働時間の初期選択の値 */
   initialHours: number;
+  /** 進捗の初期選択の値 */
+  initProgressRange: number;
   /** ダイアログ閉じるイベント */
   onClose: () => void;
 };
@@ -44,6 +46,7 @@ export default function TaskEditDialog({
   initialCategoryId,
   initialTaskId,
   initialHours,
+  initProgressRange,
   open,
   onClose,
 }: Props) {
@@ -60,6 +63,8 @@ export default function TaskEditDialog({
     onChangeSelectCategory,
     onChangeSelectTask,
     onChangeSelectHours,
+    progress,
+    handleChangeProgress,
     handleSave,
     handleDelete,
     onCreateTask,
@@ -69,6 +74,7 @@ export default function TaskEditDialog({
     initialCategoryId,
     initialTaskId,
     initialHours,
+    initProgressRange,
     onClose,
   });
   const {
@@ -207,8 +213,8 @@ export default function TaskEditDialog({
                 <Slider
                   aria-labelledby="slider-label"
                   name="progress-slider"
-                  value={50} // TODO: 値をstateで管理する場合はstateに置き換え
-                  onChange={() => {}} // TODO: 値の更新処理を追加
+                  value={progress}
+                  onChange={handleChangeProgress}
                   step={10}
                   valueLabelDisplay="auto"
                   sx={{

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -15,6 +15,8 @@ type Props = {
   initialTaskId: number;
   /** 稼働時間の初期選択の値 */
   initialHours: number;
+  /** 進捗の初期選択の値 */
+  initProgressRange: number;
   /** ダイアログ閉じるイベント */
   onClose: () => void;
 };
@@ -27,6 +29,7 @@ export default function TaskEditDialogLogic({
   initialCategoryId,
   initialTaskId,
   initialHours,
+  initProgressRange,
   onClose,
 }: Props) {
   // ぱらめーた
@@ -128,6 +131,15 @@ export default function TaskEditDialogLogic({
     setDailyHours(Number(target));
   }, []);
 
+  // 進捗関連
+  const [progress, setProgress] = useState<number>(initProgressRange);
+  const handleChangeProgress = useCallback(
+    (_: Event, newValue: number | number[]) => {
+      if (typeof newValue === "number") setProgress(newValue);
+    },
+    []
+  );
+
   const handleSave = useCallback(async () => {
     // 各stateの値について、初期値と一緒なら処理に含めない
     const body: Record<string, number> = {};
@@ -192,6 +204,10 @@ export default function TaskEditDialogLogic({
     onChangeSelectTask,
     /** 選択した稼働時間に変更するハンドラー */
     onChangeSelectHours,
+    /** 進捗 */
+    progress,
+    /** 進捗を変えるハンドラー */
+    handleChangeProgress,
     /** 編集を保存するハンドラー */
     handleSave,
     /** デリートのイベント */


### PR DESCRIPTION
# 変更点
- 進捗を変更するバーを日付ページのタスク編集時のダイアログに追加

# 詳細
- タスク編集ダイアログに進捗いじるバーを追加
  - 稼働時間とメモボタンの間に配置
    - 稼働時間の幅をちょい狭めてスタイルも場所を取らないstandardに変更して配置
  - InputLabelっぽい見た目でTypo配置して色は灰色で
- 進捗関連のパラメータ追加
  - stateで管理