### PR TITLE
Selectのdisabled風のUIを作成

### DIFF
--- a/my-app/src/component/SelectLikeDisplay/SelectLikeDisplay.stories.tsx
+++ b/my-app/src/component/SelectLikeDisplay/SelectLikeDisplay.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SelectLikeDisplay from "./SelectLikeDisplay";
+
+const meta = {
+  component: SelectLikeDisplay,
+  args: { text: "表示文言", width: 200 },
+} satisfies Meta<typeof SelectLikeDisplay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/component/SelectLikeDisplay/SelectLikeDisplay.tsx
+++ b/my-app/src/component/SelectLikeDisplay/SelectLikeDisplay.tsx
@@ -1,0 +1,46 @@
+import { memo } from "react";
+import { Box, Typography } from "@mui/material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+
+type Props = {
+  /** 表示文言 */
+  text: string;
+  /** 全体の幅 */
+  width: number;
+};
+
+/**
+ * MUIのセレクト(outlined)風のディスプレイコンポーネント
+ */
+const SelectLikeDisplay = memo(function SelectLikeDisplay({
+  text,
+  width,
+}: Props) {
+  return (
+    <Box
+      sx={{
+        border: "1px solid",
+        borderColor: "rgba(0, 0, 0, 0.23)", // outlinedと同じ色
+        borderRadius: "4px",
+        padding: "16px 8px 16px 14px",
+        display: "flex",
+        width,
+        alignItems: "center",
+        justifyContent: "space-between",
+        color: "rgba(0, 0, 0, 0.38)", // disabledなTypography色
+        cursor: "default",
+        fontSize: "1rem",
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: "1rem",
+        }}
+      >
+        {text}
+      </Typography>
+      <ArrowDropDownIcon />
+    </Box>
+  );
+});
+export default SelectLikeDisplay;


### PR DESCRIPTION
# 変更点
- Selectっぽい感じのUI作成

# 詳細
- Selectのdisabled風のUIを作成
  - BoxとTypoとIconで作成
  - 固定値で使用する場合にSelectを使用するよりもパフォーマンスで優秀
    - Selectを使う場所の固定値バージョンの置き換え先として利用する予定
  - 全体の幅と表示文言を引数に持つ