### PR TITLE
Sliderのdisabled風のUIを作成

### DIFF
--- a/my-app/src/component/SliderLikeDisplay/SliderLikeDisplay.stories.tsx
+++ b/my-app/src/component/SliderLikeDisplay/SliderLikeDisplay.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SliderLikeDisplay from "./SliderLikeDisplay";
+
+const meta = {
+  component: SliderLikeDisplay,
+  args: {
+    title: "タイトル",
+    width: 300,
+    value: 100,
+  },
+} satisfies Meta<typeof SliderLikeDisplay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/component/SliderLikeDisplay/SliderLikeDisplay.tsx
+++ b/my-app/src/component/SliderLikeDisplay/SliderLikeDisplay.tsx
@@ -1,0 +1,61 @@
+import { Box, Typography } from "@mui/material";
+import { memo } from "react";
+
+type Props = {
+  /** タイトル */
+  title: string;
+  /** 幅 */
+  width: number;
+  /** 固定の値(0(左端),100(右端)) */
+  value: number;
+};
+
+/**
+ * スライダーふうのdisplay
+ */
+const SliderLikeDisplay = memo(function SliderLikeDisplay({
+  title,
+  width,
+  value,
+}: Props) {
+  return (
+    <>
+      <Typography
+        fontSize="0.875rem"
+        color="text.secondary"
+        sx={{
+          pointerEvents: "none", // ← これでカーソル無効化
+        }}
+      >
+        {title}
+      </Typography>
+      {/** 棒の部分 */}
+      <Box
+        mb={"13px"}
+        mt={0.75}
+        sx={{
+          position: "relative",
+          height: 4,
+          borderRadius: 2,
+          width,
+          backgroundColor: "grey.400", // track色
+        }}
+      >
+        {/* たま */}
+        <Box
+          sx={{
+            position: "absolute",
+            right: width * (1 - value / 100),
+            top: "50%",
+            transform: `translate(50%, -50%)`,
+            width: 20,
+            height: 20,
+            borderRadius: "50%",
+            backgroundColor: "grey.500", // thumb色
+          }}
+        />
+      </Box>
+    </>
+  );
+});
+export default SliderLikeDisplay;


### PR DESCRIPTION
タイトル通り

# 詳細
- Sliderの見た目っぽいUI作成
  - BoxとTypoで作成
    - Slider使う場合と比べてパフォーマンスで優秀
  - タイトル名と全体の幅と固定値の値(0~100)を引数で受け取る