### PR TITLE
進捗の部分の文言を修正

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/CompletedTaskEditDialog/CompletedTaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/CompletedTaskEditDialog/CompletedTaskEditDialog.tsx
@@ -123,7 +123,11 @@ const CompletedTaskEditDialog = memo(function CompletedTaskEditDialog({
                 </Select>
               </FormControl>
               {/** 進捗 */}
-              <SliderLikeDisplay title={"進捗"} width={250} value={100} />
+              <SliderLikeDisplay
+                title={"タスク全体の進捗"}
+                width={250}
+                value={100}
+              />
               {/** メモ追加ボタン */}
               <Button startIcon={<AddCommentIcon />} onClick={onOpenMemo}>
                 メモを追加

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -213,7 +213,7 @@ export default function TaskEditDialog({
                       pointerEvents: "none", // ← これでカーソル無効化
                     }}
                   >
-                    進捗
+                    タスク全体の進捗
                   </Typography>
                   <Slider
                     aria-labelledby="slider-label"


### PR DESCRIPTION
# 変更点
- タスク編集時の進捗部分の文言を修正

# 詳細
- 日付詳細ページのタスク/完了タスクの編集ダイアログの進捗に関する文言を変更
  - 進捗 -> タスク全体の進捗 へ更新
  - 「その日の分の進捗」ではなく、「タスク自身の進捗」であることを強調するため