### PR TITLE
Feature/open confirm dialog when complete task at task edit dialog

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialog.tsx
@@ -63,6 +63,7 @@ export default function TaskEditDialog({
     onChangeSelectTask,
     onChangeSelectHours,
     progress,
+    isBecomeComplete,
     handleChangeProgress,
     handleSave,
     handleDelete,
@@ -283,7 +284,7 @@ export default function TaskEditDialog({
               startIcon={<CheckCircleIcon />}
               variant="contained"
               disabled={unSelected}
-              onClick={handleSave}
+              onClick={isBecomeComplete ? onOpenComplete : handleSave} // 完了状態になる場合はダイアログをはさむ
             >
               保存
             </Button>

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/TaskEditDialogLogic.ts
@@ -137,6 +137,7 @@ export default function TaskEditDialogLogic({
   );
   const initProgress = progressData?.body.progress;
   const [progress, setProgress] = useState<number | null>(null);
+  const isBecomeComplete = useMemo(() => progress === 100, [progress]);
   const handleChangeProgress = useCallback(
     (_: Event, newValue: number | number[]) => {
       if (typeof newValue === "number") setProgress(newValue);
@@ -221,6 +222,8 @@ export default function TaskEditDialogLogic({
     onChangeSelectHours,
     /** 進捗 */
     progress,
+    /** 進捗の更新後の値が完了状態(100%)かどうか */
+    isBecomeComplete,
     /** 進捗を変えるハンドラー */
     handleChangeProgress,
     /** 編集を保存するハンドラー */


### PR DESCRIPTION
# 変更点
- 日付ページでタスクを完了状態(progress:100)にする場合にダイアログをはさむように変更

# 詳細
- CompleteConfirmダイアログを繋ぎ込み
  - 変更先のprogressが100かどうかをフラグで管理してフラグ次第でダイアログを噛ませる