### PR TITLE
ボーダー表示なくなってたので設定を調整

### DIFF
--- a/my-app/src/app/work-log/task/[id]/memo-list/row/MemoListRow.tsx
+++ b/my-app/src/app/work-log/task/[id]/memo-list/row/MemoListRow.tsx
@@ -70,7 +70,7 @@ export default function MemoListRow({ memoItem, isActive, onClickRow }: Props) {
           </IconButton>
         </TableCell>
       </TableRow>
-      <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
+      <TableRow>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={4}>
           <Collapse in={isActive} timeout="auto" unmountOnExit>
             <Box margin={1}>{memoItem.summary}</Box>


### PR DESCRIPTION
タイトル通り

# 詳細
- 日付詳細の目もリストについて
  - メモ間のボーダーなかった問題
  - Collaspの行の方の下線ボーダーを非表示 -> 表示に切り替えて表示