### PR TITLE
Feature/tag edit dialog display tag item

### DIFF
--- a/my-app/src/component/dialog/TagEditDialog/list/DisplayTagItem/DisplayTagItem.stories.tsx
+++ b/my-app/src/component/dialog/TagEditDialog/list/DisplayTagItem/DisplayTagItem.stories.tsx
@@ -1,15 +1,14 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import DisplayTagItem from './DisplayTagItem';
+import DisplayTagItem from "./DisplayTagItem";
 
 const meta = {
   component: DisplayTagItem,
+  args: { tagName: "タグ1", onClickEdit: () => {}, onClickDelete: () => {} },
 } satisfies Meta<typeof DisplayTagItem>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {}
-};
+export const Default: Story = {};

--- a/my-app/src/component/dialog/TagEditDialog/list/DisplayTagItem/DisplayTagItem.tsx
+++ b/my-app/src/component/dialog/TagEditDialog/list/DisplayTagItem/DisplayTagItem.tsx
@@ -2,22 +2,35 @@ import { IconButton, ListItemText, Stack } from "@mui/material";
 import { memo } from "react";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+
+type Props = {
+  /** タグ名 */
+  tagName: string;
+  /** 編集ボタン押した時のハンドラー */
+  onClickEdit: () => void;
+  /** 削除ボタン押した時のハンドラー */
+  onClickDelete: () => void;
+};
 /**
  * タグリストの表示時のアイテム
  */
-const DisplayTagItem = memo(function DisplayTagItem() {
+const DisplayTagItem = memo(function DisplayTagItem({
+  tagName,
+  onClickEdit,
+  onClickDelete,
+}: Props) {
   return (
     <Stack direction="row" justifyContent={"space-between"}>
       {/** 左側(タグ名表示) */}
-      <ListItemText primary={"タグ名" /** TODO:親からもらう */} />
+      <ListItemText primary={tagName} />
       {/** 右側(ボタン部分) */}
       <Stack direction="row">
         {/** 編集ボタン */}
-        <IconButton color="primary">
+        <IconButton color="primary" onClick={onClickEdit}>
           <EditIcon />
         </IconButton>
         {/** 削除ボタン */}
-        <IconButton color="error">
+        <IconButton color="error" onClick={onClickDelete}>
           <DeleteIcon />
         </IconButton>
       </Stack>


### PR DESCRIPTION
# 変更点
- タグ編集用のダイアログ用のリストアイテムの通常時のコンポーネントを作成

# 詳細
- タグ名とボタンを表示
  - 左部分にタグ名、右部分にはボタンを表示
  - 編集/削除のアイコンボタンを表示
  - タグ名とボタンのハンドラーは親から取得

# 注意点
- UI調整について
  - 実際にリスト化してからどんな感じになるかを見てから微調整を予定
  - 現状はパーツ分けのみ(文言/ボタン部分)