### PR TITLE
UI作成

### DIFF
--- a/my-app/src/component/SettingsDrawer/SettingsDrawer.stories.tsx
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawer.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SettingsDrawer from './SettingsDrawer';
+
+const meta = {
+  component: SettingsDrawer,
+} satisfies Meta<typeof SettingsDrawer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
@@ -1,0 +1,88 @@
+import {
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { memo } from "react";
+import MenuIcon from "@mui/icons-material/Menu";
+import FileUploadIcon from "@mui/icons-material/FileUpload";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+import ContrastIcon from "@mui/icons-material/Contrast";
+
+/**
+ * データ管理/表示設定を表示するドロワー + それを開閉するボタン
+ */
+const SettingsDrawer = memo(function SettingsDrawer() {
+  return (
+    <>
+      {/** 開閉用のボタン */}
+      <IconButton>
+        <MenuIcon />
+      </IconButton>
+      {/** サイドバー */}
+      <Drawer open={true /** TODO:あとで修正 */}>
+        {/**　コンテンツ */}
+        <List>
+          {/** データ管理(タイトル) */}
+          <ListItem>
+            <ListItemText primary="▼　データ管理" />
+          </ListItem>
+          {/** データ管理(各項目) */}
+          <List sx={{ pl: 1, py: 0 }}>
+            {/** インポート */}
+            <ListItem disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  <FileUploadIcon />
+                </ListItemIcon>
+                <ListItemText primary={"インポート"} />
+              </ListItemButton>
+            </ListItem>
+            {/** エクスポート */}
+            <ListItem disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  <FileDownloadIcon />
+                </ListItemIcon>
+                <ListItemText primary={"エクスポート"} />
+              </ListItemButton>
+            </ListItem>
+            {/** データリセット */}
+            <ListItem disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  <DeleteForeverIcon />
+                </ListItemIcon>
+                <ListItemText primary={"データリセット"} />
+              </ListItemButton>
+            </ListItem>
+          </List>
+          {/** 分割線 */}
+          <Divider sx={{ width: "90%", justifySelf: "center", my: 2 }} />
+          {/** 表示設定(タイトル) */}
+          <ListItem>
+            <ListItemText primary="▼　表示設定" />
+          </ListItem>
+          {/** 表示設定(各項目) */}
+          <List sx={{ pl: 1, py: 0 }}>
+            <ListItem disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  <ContrastIcon />
+                </ListItemIcon>
+                <ListItemText primary={"テーマ切り替え"} />
+              </ListItemButton>
+            </ListItem>
+          </List>
+        </List>
+      </Drawer>
+    </>
+  );
+});
+export default SettingsDrawer;


### PR DESCRIPTION
タイトル通り

# 詳細
- ドロワー + 展開するボタンでコンポーネント作成
- 中身はネストしたListで作成
  - データ管理/表示設定でListを作成し、それぞれが子のListを保持する
  - タイトル部分はListItemTextで表示し、子はListItemButtonでクリック可能
  - 各大項目ごとにDividerで分断して表示