### PR TITLE
else内で行う処理を位置みすって常に走ってたので修正

### DIFF
--- a/my-app/src/lib/local-services/dailyDetailService.ts
+++ b/my-app/src/lib/local-services/dailyDetailService.ts
@@ -84,8 +84,8 @@ export const getDailyDetailData = async (date: string) => {
       tagName = tagData.name;
     } else {
       // idない場合は未選択に
+      tagName = "未選択";
     }
-    tagName = "未選択";
     return {
       id,
       title,


### PR DESCRIPTION
# 変更点
- 日付詳細ページにおいて、タグを設定した場合にも未設定と表示されるバグを修正
# 詳細
- tagNameを取得する際に、メモにtagIdが含まれていない場合の処理に誤りがあったため修正
  - 本来の想定
    - tagIdがある場合 -> タグ一覧からidが一致するものからnameを取得
    - tagIdがない場合 -> "未選択"
  - 実際の挙動
    - tagIdがある場合 ->取得
    - tagIdがない場合 -> なにもしない(空{ }になってた)
    - その後 -> "未選択"
  - if/elseの処理でelse内に"未選択"にする処理を移動することで修正