### PR TITLE
valueを元にcheckedを制御させてお気に入りの場合に最初からチェックされた状態で表示させる

### DIFF
--- a/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialog.tsx
@@ -107,7 +107,9 @@ export default function TaskEditDialog({
               <Controller
                 name={"isFavorite"}
                 control={control}
-                render={({ field }) => <Checkbox {...field} />}
+                render={({ field }) => (
+                  <Checkbox {...field} checked={field.value} />
+                )}
               />
             }
             label="お気に入り"


### PR DESCRIPTION
# 詳細
- タスク詳細 編集ダイアログについて
  - お気に入りであった場合でもチェックボックスが未入力であった点
  - 加えて、その状態でチェックボックスを操作すると送信データとチェックボックスの状態と反対の値を示していた点
    - チェックされてる状態がお気に入りでない状態、といった具合
# 対処
- チェックボックスのチェック状態をcheckedで管理することで対処 