### PR TITLE
ナビゲーションバーに設定用のドロワーの開閉ボタン配置

### DIFF
--- a/my-app/src/component/Navbar/Navbar.tsx
+++ b/my-app/src/component/Navbar/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Box, Breadcrumbs, Button, Typography } from "@mui/material";
 import { NavBarLogic } from "./logic";
+import SettingsDrawer from "../SettingsDrawer/SettingsDrawer";
 
 /**
  *  ナビゲーションバーの共通コンポーネント
@@ -30,6 +31,8 @@ export default function Navbar() {
           boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
         }}
       >
+        {/** メニューボタン */}
+        <SettingsDrawer />
         {/** ナビゲーション部分 */}
         <Breadcrumbs separator="›" aria-label="breadcrumb">
           {navPages.map((navPage, index) => {

--- a/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
@@ -32,7 +32,7 @@ const SettingsDrawer = memo(function SettingsDrawer() {
   return (
     <>
       {/** 開閉用のボタン */}
-      <IconButton onClick={onOpen}>
+      <IconButton sx={{ py: 0.3 }} onClick={onOpen}>
         <MenuIcon />
       </IconButton>
       {/** サイドバー */}


### PR DESCRIPTION
タイトル通り

# 詳細
- メニューの左部分にボタンを配置
  - テキストの高さに合わせるためにボタンのpaddingを調整