### PR TITLE
円グラフのダークモード適応漏れ修正

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/circle-graph/CircleGraph.tsx
+++ b/my-app/src/app/work-log/daily/[date]/circle-graph/CircleGraph.tsx
@@ -15,7 +15,7 @@ type Props = {
  * 日付詳細 - 円グラフコンポーネント
  */
 export default function CircleGraph({ data }: Props) {
-  const { isNoData, getLabel } = CircleGraphLogic({ data });
+  const { theme, isNoData, getLabel } = CircleGraphLogic({ data });
   return (
     <>
       {!isNoData && (
@@ -26,7 +26,7 @@ export default function CircleGraph({ data }: Props) {
             cx="50%"
             cy="50%"
             outerRadius={90}
-            fill={"#8884d8"}
+            fill={theme.palette.recharts.pie.defaultFill}
             label={getLabel}
           />
           <Tooltip

--- a/my-app/src/app/work-log/daily/[date]/circle-graph/CircleGraphLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/circle-graph/CircleGraphLogic.ts
@@ -1,4 +1,5 @@
 import { DailyCategoryCircleGraph } from "@/type/Date";
+import { useTheme } from "@mui/material";
 import { useCallback, useMemo } from "react";
 import { PieLabelRenderProps } from "recharts";
 
@@ -11,6 +12,8 @@ type Props = {
  * 日付詳細 - 円グラフコンポーネントのロジック部分
  */
 export default function CircleGraphLogic({ data }: Props) {
+  // MUIのテーマ呼び出し
+  const theme = useTheme();
   const isNoData = useMemo(() => data.length === 0, [data]);
   const getLabel = useCallback(
     ({ name, percent }: PieLabelRenderProps) =>
@@ -19,6 +22,8 @@ export default function CircleGraphLogic({ data }: Props) {
   );
 
   return {
+    /** MUIのテーマ */
+    theme,
     /** データの有無 */
     isNoData,
     /** ラベルを取得する関数 引数はPieのLabelのprops */


### PR DESCRIPTION
タイトル通り

# 詳細
- 日付詳細 円グラフの色を既存のテーマから取得してダークモードに適応