### PR TITLE
PalletOptionsでstring指定できる部分で呼び出してたthemeの部分を置き換え

### DIFF
--- a/my-app/src/app/work-log/component/nav-menu/NavMenuLogic.ts
+++ b/my-app/src/app/work-log/component/nav-menu/NavMenuLogic.ts
@@ -1,14 +1,13 @@
-import { Theme } from "@mui/material/styles";
 import { format, subDays } from "date-fns";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 /**
  * メインページのナビゲーションメニューのロジック
  */
 export default function NavMenuLogic() {
   const router = useRouter();
-  const navButtonStyle = useCallback((theme: Theme) => {
+  const navButtonStyle = useMemo(() => {
     return {
       display: "flex",
       flexDirection: "column",
@@ -21,7 +20,7 @@ export default function NavMenuLogic() {
       transition: "all 0.2s",
       "&:hover": {
         bgcolor: "primary.light",
-        color: theme.palette.hoverContrastText,
+        color: "hoverContrastText",
         transform: "translateY(-2px)",
       },
     };

--- a/my-app/src/app/work-log/component/work-time-heat-graph/RecentWorkHeatMap.tsx
+++ b/my-app/src/app/work-log/component/work-time-heat-graph/RecentWorkHeatMap.tsx
@@ -62,17 +62,17 @@ const RecentWorkHeatMap = memo(function RecentWorkHeatMap() {
               >
                 {/** 列(表示されるボックスごと) */}
                 <Box
-                  sx={(theme) => ({
+                  sx={{
                     width: boxSize,
                     height: boxSize,
-                    bgcolor: getColorByHours(theme, item.totalHours),
+                    bgcolor: getColorByHours(item.totalHours),
                     borderRadius: 1,
                     cursor: "pointer",
                     transition: "transform 0.15s",
                     "&:hover": {
                       transform: "scale(1.1)",
                     },
-                  })}
+                  }}
                   onClick={() => onClick(item.date)}
                 />
               </Tooltip>
@@ -80,12 +80,12 @@ const RecentWorkHeatMap = memo(function RecentWorkHeatMap() {
               /** データがない場合の表示(ツールチップ/ホバー時のtransitionなし/クリック時のイベントもなし) */
               <Box
                 key={i}
-                sx={(theme) => ({
+                sx={{
                   width: boxSize,
                   height: boxSize,
-                  bgcolor: theme.palette.gray.normal,
+                  bgcolor: "gray.normal",
                   borderRadius: 1,
-                })}
+                }}
               />
             )
           )}

--- a/my-app/src/app/work-log/component/work-time-heat-graph/RecentWorkHeatMapLogic.ts
+++ b/my-app/src/app/work-log/component/work-time-heat-graph/RecentWorkHeatMapLogic.ts
@@ -1,6 +1,5 @@
 import { localClient } from "@/lib/localClient";
 import { DailyWorkTime } from "@/type/Main";
-import { Theme } from "@mui/material/styles";
 import { format, getDay, isSameDay, parseISO, subDays } from "date-fns";
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
@@ -73,11 +72,11 @@ export const RecentWorkHeatMapLogic = () => {
   );
   const data = useMemo(() => rawData ?? [], [rawData]);
 
-  const getColorByHours = useCallback((theme: Theme, hours: number) => {
-    if (hours <= 1) return theme.palette.heatGraph.blue[0];
-    if (hours <= 3) return theme.palette.heatGraph.blue[1];
-    if (hours <= 6) return theme.palette.heatGraph.blue[2];
-    return theme.palette.heatGraph.blue[3];
+  const getColorByHours = useCallback((hours: number) => {
+    if (hours <= 1) return "heatGraph.blue.0";
+    if (hours <= 3) return "heatGraph.blue.1";
+    if (hours <= 6) return "heatGraph.blue.2";
+    return "heatGraph.blue.3";
   }, []);
 
   const getDisplayTime = useCallback((hours: number) => {

--- a/my-app/src/app/work-log/daily/[date]/memo-list/table-body/CustomTableBodyLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/memo-list/table-body/CustomTableBodyLogic.ts
@@ -1,5 +1,4 @@
-import { Theme } from "@mui/material";
-import { useCallback } from "react";
+import { useMemo } from "react";
 
 type Props = {
   /** ハイライトされてるか(選択中のタスクのメモであるか) */
@@ -10,9 +9,9 @@ type Props = {
  * 日次詳細 - メモリストのテーブルボディコンポーネントのロジック
  */
 export const CustomTableBodyLogic = ({ isHighlighted }: Props) => {
-  const backgroundColor = useCallback(
+  const backgroundColor = useMemo(
     // ハイライト時には薄い青色 (選択時はselectedによって上書きされるので注意)
-    (theme: Theme) => (isHighlighted ? theme.palette.table.highlighted : ""),
+    () => (isHighlighted ? "table.highlighted" : ""),
     [isHighlighted]
   );
   return {

--- a/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenu.tsx
+++ b/my-app/src/app/work-log/daily/[date]/menu/DailyDetailMenu.tsx
@@ -56,12 +56,12 @@ export default function DailyDetailMenu({ date, dailyHours, taskList }: Props) {
               })}
             >
               <Stack
-                sx={(theme) => ({
+                sx={{
                   height: "100%",
                   width: "0%",
-                  backgroundColor: theme.palette.gray.normal,
+                  backgroundColor: "gray.normal",
                   animation: `${growAnimation} 1s ease-out forwards`,
-                })}
+                }}
               />
             </Stack>
           </Stack>


### PR DESCRIPTION
タイトル通り

# 詳細
- 修正前:sx={(theme)=> ... color:theme.pallet.xxx.bbb
- 修正後 sx={{ ... color:"xxx.bbb"
- この修正による機能面は特に変化なし(どちらも参照先は同じため)
  - 可読性向上が目的