### PR TITLE
Feature/check over write logic when import db

### DIFF
--- a/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawer.tsx
@@ -17,6 +17,7 @@ import ContrastIcon from "@mui/icons-material/Contrast";
 import DataResetDialog from "./dialog/DataResetDialog/DataResetDialog";
 import useDialog from "@/hook/useDialog";
 import { SettingsDrawerLogic } from "./SettingsDrawerLogic";
+import ImportOverwriteDialog from "../dialog/ImportOverwriteDialog/ImportOverwriteDialog";
 
 type Props = {
   /** テーマ変更関数 */
@@ -32,15 +33,21 @@ const SettingsDrawer = memo(function SettingsDrawer({ onChangeTheme }: Props) {
     onClose: onCloseReset,
   } = useDialog();
   const {
+    open: openOverWrite,
+    onOpen: onOpenOverWrite,
+    onClose: onCloseOverWrite,
+  } = useDialog();
+  const {
     open,
     onOpen,
     onClose,
     fileInputRef,
+    onImport,
     onClickImport,
     handleFileChange,
     onClickExport,
     onClickTheme,
-  } = SettingsDrawerLogic({ onChangeTheme });
+  } = SettingsDrawerLogic({ onChangeTheme, onOpenOverWrite });
   return (
     <>
       {/** 開閉用のボタン */}
@@ -114,6 +121,13 @@ const SettingsDrawer = memo(function SettingsDrawer({ onChangeTheme }: Props) {
         </List>
       </Drawer>
       {openReset && <DataResetDialog open={openReset} onClose={onCloseReset} />}
+      {openOverWrite && (
+        <ImportOverwriteDialog
+          open={openOverWrite}
+          onClose={onCloseOverWrite}
+          onImport={onImport}
+        />
+      )}
     </>
   );
 });

--- a/my-app/src/component/SettingsDrawer/SettingsDrawerLogic.ts
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawerLogic.ts
@@ -1,16 +1,26 @@
-import { exportDatabase, importDatabase } from "@/lib/dexie";
+import {
+  exportDatabase,
+  ImportData,
+  importDatabase,
+  isDatabaseExist,
+} from "@/lib/dexie";
 import { useCallback, useRef, useState } from "react";
 import { mutate } from "swr";
 
 type Props = {
   /** テーマ変更関数 */
   onChangeTheme: () => void;
+  /** 上書き確認ダイアログの開くロジック */
+  onOpenOverWrite: () => void;
 };
 
 /**
  * データ管理/表示設定を表示するドロワー + それを開閉するボタンのロジック
  */
-export const SettingsDrawerLogic = ({ onChangeTheme }: Props) => {
+export const SettingsDrawerLogic = ({
+  onChangeTheme,
+  onOpenOverWrite,
+}: Props) => {
   // ドロワーの開閉関連
   const [open, setOpen] = useState<boolean>(false);
 
@@ -19,12 +29,28 @@ export const SettingsDrawerLogic = ({ onChangeTheme }: Props) => {
 
   // 各項目
   // データ管理関連
+  // インポート対象のデータ
+  const importData = useRef<ImportData | null>(null);
   // refを使ってファイルを選択する
   const fileInputRef = useRef<HTMLInputElement>(null);
   const onClickImport = useCallback(() => {
     // ファイル選択のinputのクリックイベントを発火させる
     fileInputRef.current?.click();
   }, []);
+
+  // インポート関数
+  const onImport = useCallback(async () => {
+    if (importData.current !== null) {
+      // インポート処理
+      await importDatabase(importData.current);
+      // 全てのキャッシュをundefinedにする(再取得させる)
+      mutate(() => true, undefined);
+      // importDataをnullにする
+      importData.current = null;
+      // 処理後、ドロワーを閉じる
+      onClose();
+    }
+  }, [onClose]);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     // インポートしたファイルを確認
@@ -33,13 +59,19 @@ export const SettingsDrawerLogic = ({ onChangeTheme }: Props) => {
     if (!file) return;
     // ファイルの内容を読み込む
     const text = await file.text();
-    const json = JSON.parse(text);
-    // インポート処理をここで呼ぶ
-    await importDatabase(json);
-    // 全てのキャッシュをundefinedにする(再取得させる)
-    mutate(() => true, undefined);
-    // 処理後、ドロワーを閉じる
-    onClose();
+    const json = JSON.parse(text) as ImportData; // dbから取るので型は同定可能
+    // インポートデータとして保持
+    importData.current = json;
+    // dbにデータがあるかチェック
+    const exist = await isDatabaseExist();
+    // データがある場合
+    if (exist) {
+      // 上書き確認ダイアログを開く
+      onOpenOverWrite();
+    } else {
+      // データがない場合は直接インポート処理を呼ぶ
+      await onImport();
+    }
   };
   const onClickExport = useCallback(() => {
     exportDatabase();
@@ -60,6 +92,8 @@ export const SettingsDrawerLogic = ({ onChangeTheme }: Props) => {
     onClose,
     /** インポート時のファイル選択のinputのref */
     fileInputRef,
+    /** インポート処理(上書き確認ダイアログにロジック受け渡しよう) */
+    onImport,
     /** インポートクリック時のハンドラー(inputのクリックイベントを渡してドロワーを閉じる) */
     onClickImport,
     /** インポート対象が設定された際のハンドラー(IndexedDB内のデータを置換)  */

--- a/my-app/src/lib/dexie.ts
+++ b/my-app/src/lib/dexie.ts
@@ -43,7 +43,7 @@ const getAllTables = () => [
 /** エクスポート時のデータの型定義 */
 type ExportData = DailyData | TaskLog | Task | Category | Memo | MemoTag;
 /** インポート時のデータの型定義 */
-type ImportData = {
+export type ImportData = {
   dailyData: DailyData[];
   taskLogs: TaskLog[];
   tasks: Task[];


### PR DESCRIPTION
# 変更点
- データをインポート時に上書きするか確認するロジック定義
- インポート時の上書き確認ダイアログを繋ぎ込み

# 詳細
- dexieに確認ロジック isDatabaseExist 追加
  - 各テーブル内にデータがあるかループで調べてあればtrueを返す
- 設定ドロワー側
  - インポート処理(インポート -> mutate -> onClose)をロジックとして分離
  - インポートデータについてrefで管理するように(ダイアログ内で参照可能にするため)
    - onChangeイベントでファイル取得後にrefに保持させ、インポート処理の引数は無しでrefから取得するように設定
  - onChangeイベントに分岐追加
    - ファイル取得(refに保持)させたのちにデータベースに存在するかチェック
      - 存在すればダイアログを開く
      - 存在しなければそのままインポート処理(以前までの処理)
- ダイアログ繋ぎ込み
  - useDialogでダイアログ関連
  - インポート時の処理として上記の分離したインポート処理を呼び出し