### PR TITLE
インポート時にmutateをawaitしてキャッシュがuiに適応されない問題を解決

### DIFF
--- a/my-app/src/component/SettingsDrawer/SettingsDrawerLogic.ts
+++ b/my-app/src/component/SettingsDrawer/SettingsDrawerLogic.ts
@@ -44,7 +44,7 @@ export const SettingsDrawerLogic = ({
       // インポート処理
       await importDatabase(importData.current);
       // 全てのキャッシュをundefinedにする(再取得させる)
-      mutate(() => true, undefined);
+      await mutate(() => true, undefined);
       // importDataをnullにする
       importData.current = null;
       // 処理後、ドロワーを閉じる


### PR DESCRIPTION
タイトル通り

# 詳細
- インポート時の以下の問題を解決
  - UIが更新されない場合がある点
- 原因
  - mutate()による再検証が行われる前にonClose()によって閉じられていたため
  -  mutate開始 -> onClose -> 再レンダー ->  (一部mutate完了前のため、そのデータが利用される) ->mutate完了
  - これによって一部が過去のデータを利用した状態で表示されていた
- 解決
  - mutateをawaitさせる
  - mutate開始 -> 終了 -> onClose -> 再レンダー　これで確実に適応されるように