### PR TITLE
ボタンの配置を左が承認系、右にキャンセルを配置するように統一

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/menu/dialog/MemoAddDialog/MemoAddDialog.tsx
@@ -158,9 +158,6 @@ export default function MemoAddDialog({
             />
           </Stack>
           <DialogActions>
-            <Button onClick={onClose} color="error">
-              キャンセル
-            </Button>
             <Button
               disabled={!isValid}
               type="submit"
@@ -168,6 +165,9 @@ export default function MemoAddDialog({
               startIcon={<NoteAddIcon />}
             >
               追加
+            </Button>
+            <Button onClick={onClose} color="error">
+              キャンセル
             </Button>
           </DialogActions>
         </form>

--- a/my-app/src/app/work-log/daily/[date]/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/menu/dialog/TaskAddDialog/TaskAddDialog.tsx
@@ -148,9 +148,6 @@ export default function TaskAddDialog({ open, onClose }: Props) {
         </Stack>
         {/** ボタン */}
         <DialogActions>
-          <Button color="error" onClick={onClose}>
-            キャンセル
-          </Button>
           <Button
             disabled={isLoading || selectedTaskId === 0}
             variant="contained"
@@ -158,6 +155,9 @@ export default function TaskAddDialog({ open, onClose }: Props) {
             onClick={handleAddDailyTask}
           >
             追加
+          </Button>
+          <Button color="error" onClick={onClose}>
+            キャンセル
           </Button>
         </DialogActions>
       </Dialog>

--- a/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialog.tsx
+++ b/my-app/src/app/work-log/task/[id]/dialog/task-edit/TaskEditDialog.tsx
@@ -117,11 +117,11 @@ export default function TaskEditDialog({
         </Stack>
         {/** ボタン */}
         <DialogActions>
-          <Button color="error" onClick={onClose}>
-            キャンセル
-          </Button>
           <Button disabled={!isValid} type={"submit"}>
             保存
+          </Button>
+          <Button color="error" onClick={onClose}>
+            キャンセル
           </Button>
         </DialogActions>
       </form>

--- a/my-app/src/component/SettingsDrawer/dialog/DataResetDialog/DataResetDialog.tsx
+++ b/my-app/src/component/SettingsDrawer/dialog/DataResetDialog/DataResetDialog.tsx
@@ -39,7 +39,6 @@ const DataResetDialog = memo(function DataResetDialog({
         </Typography>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>キャンセル</Button>
         <Button
           color="error"
           startIcon={<DeleteForeverIcon />}
@@ -47,6 +46,7 @@ const DataResetDialog = memo(function DataResetDialog({
         >
           削除
         </Button>
+        <Button onClick={onClose}>キャンセル</Button>
       </DialogActions>
     </Dialog>
   );

--- a/my-app/src/component/dialog/CreateCategoryDialog/CreateCategoryDialog.tsx
+++ b/my-app/src/component/dialog/CreateCategoryDialog/CreateCategoryDialog.tsx
@@ -56,9 +56,6 @@ export default function CreateCategoryDialog({
         </DialogContent>
         {/** ロウワー ボタン */}
         <DialogActions>
-          <Button onClick={onClose} color="error">
-            キャンセル
-          </Button>
           <Button
             disabled={!isValid}
             type="submit"
@@ -66,6 +63,9 @@ export default function CreateCategoryDialog({
             startIcon={<AddBoxIcon />}
           >
             作成
+          </Button>
+          <Button onClick={onClose} color="error">
+            キャンセル
           </Button>
         </DialogActions>
       </form>

--- a/my-app/src/component/dialog/CreateTagDialog/CreateTagDialog.tsx
+++ b/my-app/src/component/dialog/CreateTagDialog/CreateTagDialog.tsx
@@ -59,11 +59,11 @@ const CreateTagDialog = memo(function CreateTagDialog({
           )}
         </DialogContent>
         <DialogActions>
-          <Button color="error" onClick={onClose}>
-            キャンセル
-          </Button>
           <Button type="submit" disabled={!isSendable}>
             作成
+          </Button>
+          <Button color="error" onClick={onClose}>
+            キャンセル
           </Button>
         </DialogActions>
       </form>

--- a/my-app/src/component/dialog/PeriodSelectDialog/PeriodSelectDialog.tsx
+++ b/my-app/src/component/dialog/PeriodSelectDialog/PeriodSelectDialog.tsx
@@ -63,11 +63,11 @@ export default function PeriodSelectDialog({
         </Stack>
       </Stack>
       <DialogActions>
-        <Button onClick={onClose} color="error">
-          キャンセル
-        </Button>
         <Button disabled={!isValid} onClick={onClickSelect}>
           選択
+        </Button>
+        <Button onClick={onClose} color="error">
+          キャンセル
         </Button>
       </DialogActions>
     </Dialog>

--- a/my-app/src/component/dialog/TagEditDialog/list/TagConfirmDeleteDialog/TagConfirmDeleteDialog.tsx
+++ b/my-app/src/component/dialog/TagEditDialog/list/TagConfirmDeleteDialog/TagConfirmDeleteDialog.tsx
@@ -67,7 +67,6 @@ const TagConfirmDeleteDialog = memo(function TagConfirmDeleteDialog({
           </DialogContent>
           {/** ボタン */}
           <DialogActions>
-            <Button onClick={onClose}>キャンセル</Button>
             <Button
               startIcon={<DeleteIcon />}
               color="error"
@@ -76,6 +75,7 @@ const TagConfirmDeleteDialog = memo(function TagConfirmDeleteDialog({
             >
               削除
             </Button>
+            <Button onClick={onClose}>キャンセル</Button>
           </DialogActions>
         </>
       )}

--- a/my-app/src/component/dialog/TagEditDialog/list/TagConfirmSaveDialog/TagConfirmSaveDialog.tsx
+++ b/my-app/src/component/dialog/TagEditDialog/list/TagConfirmSaveDialog/TagConfirmSaveDialog.tsx
@@ -71,7 +71,6 @@ const TagConfirmSaveDialog = memo(function TagConfirmSaveDialog({
           </DialogContent>
           {/** ボタン */}
           <DialogActions>
-            <Button onClick={onClose}>キャンセル</Button>
             <Button
               startIcon={<CheckCircleIcon />}
               color="success"
@@ -79,6 +78,7 @@ const TagConfirmSaveDialog = memo(function TagConfirmSaveDialog({
             >
               保存
             </Button>
+            <Button onClick={onClose}>キャンセル</Button>
           </DialogActions>
         </>
       )}


### PR DESCRIPTION
タイトル通り

# 詳細
- 各ダイアログについて
  - <DialogActions>内で定義されているボタンについて
    - 左側に削除・追加・承認などの特有のアクションがくるように設定
    - 右側にキャンセルがくるように設定