### PR TITLE
日付一覧でヘッダー部分のロード状態の状態を削除

### DIFF
--- a/my-app/src/app/work-log/daily/header/DailyHeader.stories.tsx
+++ b/my-app/src/app/work-log/daily/header/DailyHeader.stories.tsx
@@ -4,10 +4,6 @@ import DailyHeader from "./DailyHeader";
 
 const meta = {
   component: DailyHeader,
-  args: {
-    isLoading: false,
-    onClickEditSelectDate: () => {},
-  },
 } satisfies Meta<typeof DailyHeader>;
 
 export default meta;

--- a/my-app/src/app/work-log/daily/header/DailyHeader.tsx
+++ b/my-app/src/app/work-log/daily/header/DailyHeader.tsx
@@ -15,14 +15,10 @@ import DailyHeaderLogic from "./DailyHeaderLogic";
 import useDialog from "@/hook/useDialog";
 import DateDialog from "../dialog/DateDialog";
 
-type Props = {
-  /** ロード中かどうか */
-  isLoading: boolean;
-};
 /**
  * 日付ページのヘッダーコンポーネント
  */
-export default function DailyHeader({ isLoading }: Props) {
+export default function DailyHeader() {
   const {
     open: openDialog,
     onClose: onCloseDialog,
@@ -78,15 +74,10 @@ export default function DailyHeader({ isLoading }: Props) {
             }}
             disabled={isStartRange}
             onClick={handlePrevMonth}
-            loading={isLoading}
           >
             <NavigateBeforeIcon />
           </IconButton>
-          <Button
-            onClick={handleOpenPopover}
-            disabled={isLoading}
-            sx={{ borderRadius: "50%" }}
-          >
+          <Button onClick={handleOpenPopover} sx={{ borderRadius: "50%" }}>
             {displayYear}年{displayMonth}月
           </Button>
           <IconButton
@@ -96,7 +87,6 @@ export default function DailyHeader({ isLoading }: Props) {
             }}
             disabled={isLastRange}
             onClick={handleNextMonth}
-            loading={isLoading}
           >
             <NavigateNextIcon />
           </IconButton>
@@ -111,12 +101,7 @@ export default function DailyHeader({ isLoading }: Props) {
         transformOrigin={{ vertical: "top", horizontal: "center" }}
       >
         <Stack direction="row" spacing={1} px={2} py={1}>
-          <FormControl
-            disabled={isLoading}
-            variant="standard"
-            fullWidth
-            sx={{ minWidth: "80px" }}
-          >
+          <FormControl variant="standard" fullWidth sx={{ minWidth: "80px" }}>
             <Select
               name="year-select"
               value={displayYear}
@@ -130,7 +115,7 @@ export default function DailyHeader({ isLoading }: Props) {
               ))}
             </Select>
           </FormControl>
-          <FormControl disabled={isLoading} fullWidth variant="standard">
+          <FormControl fullWidth variant="standard">
             <Select
               name="month-select"
               value={displayMonth}

--- a/my-app/src/app/work-log/daily/page.tsx
+++ b/my-app/src/app/work-log/daily/page.tsx
@@ -16,7 +16,7 @@ export default function DailyPage() {
   return (
     <>
       <Stack spacing={2}>
-        <DailyHeader isLoading={isLoadingItemList} />
+        <DailyHeader />
         <DailyTable
           itemList={itemList}
           onClickRow={handleNavigateSelectedDay}


### PR DESCRIPTION
タイトル通り

- 日付操作はロード状態とは関係ない(非同期処理が含まれない)
- ある特定の月のデータが欲しい場合にその間の月で止められるのは不便であると感じたので
  - 例えば、2025年5月から2025年3月へ移動する場合
    - isLoadingあり -> 月移動( "<" )で移動する場合は4月のデータロード中に操作不能となる
    - isLoadingなし -> 4月がロード中でも移動できる

加えて、ロード状態を管理する場合はページ全体で管理する必要がありコストがかかる
こういった理由で削除