### PR TITLE
ナビゲーションロジックを直接関数で渡せるように変更(参照のメモ化のため)

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/TaskList.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/TaskList.tsx
@@ -51,10 +51,8 @@ export default function TaskList({ selectedItemId, handleClickRow }: Props) {
           onClickEdit={
             isSelectedTaskCompleted ? onOpenEditCompleted : onOpenEdit
           }
-          onClickNavigateTask={() => navigateTaskPage(selectedItemTaskId)}
-          onClickNavigateCategory={() =>
-            navigateCategoryPage(selectedItemCategoryId)
-          }
+          onClickNavigateTask={navigateTaskPage}
+          onClickNavigateCategory={navigateCategoryPage}
         />
         <TaskTable
           taskList={taskList}

--- a/my-app/src/app/work-log/daily/[date]/task-list/TaskListLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/TaskListLogic.ts
@@ -63,18 +63,12 @@ export default function TaskListLogic({ selectedItemId }: Props) {
 
   // ページ移動関連
   const router = useRouter();
-  const navigateTaskPage = useCallback(
-    (id: number) => {
-      router.push(`/work-log/task/${id}`);
-    },
-    [router]
-  );
-  const navigateCategoryPage = useCallback(
-    (id: number) => {
-      router.push(`/work-log/category/?id=${id}`);
-    },
-    [router]
-  );
+  const navigateTaskPage = useCallback(() => {
+    router.push(`/work-log/task/${selectedItemTaskId}`);
+  }, [router, selectedItemTaskId]);
+  const navigateCategoryPage = useCallback(() => {
+    router.push(`/work-log/category/?id=${selectedItemCategoryId}`);
+  }, [router, selectedItemCategoryId]);
 
   return {
     /** タスク一覧 */


### PR DESCRIPTION
タイトル通り

ナビゲーションロジックを直接関数で渡せるようにすることでメモ化時に役立つため
具体的には、event={()=>function()}これでfunctionがメモ化されていても常に新しい参照となる都合再生成が行われてしまう
この場合にコンポーネントをメモ化している場合、毎回propが変更されてると検知されるため意味がなくなる

ナビゲーションロジックから引数をなくすことで直接関数を渡せるようにして対処
代わりに、移動先のタスク/カテゴリは選択中のアイテムから直接取得するように変更