### PR TITLE
UI/custom table styles

### DIFF
--- a/my-app/src/component/table/CustomTable/CustomTable.tsx
+++ b/my-app/src/component/table/CustomTable/CustomTable.tsx
@@ -77,6 +77,8 @@ const CustomTable = memo(function CustomTable<T extends { id: number }>({
   onClickRow,
 }: CustomTableProps<T>) {
   const {
+    bodyStyle,
+    headerStyle,
     isAsc,
     isSelected,
     handleClickSortLabel,
@@ -100,7 +102,7 @@ const CustomTable = memo(function CustomTable<T extends { id: number }>({
         <TableHead>
           <TableRow>
             {columns.map((col) => (
-              <TableCell key={String(col.key)} sx={{ width: col.width }}>
+              <TableCell key={String(col.key)} sx={headerStyle(col)}>
                 {/** ソートラベル */}
                 {col.labelProp === "sortable" && (
                   <CustomHeaderSortLabel
@@ -149,7 +151,7 @@ const CustomTable = memo(function CustomTable<T extends { id: number }>({
                 >
                   {columns.map((col) => (
                     /** データ内のprop数分のセルを展開 */
-                    <TableCell key={String(col.key)}>
+                    <TableCell key={String(col.key)} sx={bodyStyle}>
                       {/** お気に入りラベルの場合は星を表示 */}
                       {col.labelProp === "favoriteToggle" &&
                         (row[col.key] ? (

--- a/my-app/src/component/table/CustomTable/useCustomTable.ts
+++ b/my-app/src/component/table/CustomTable/useCustomTable.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ColumnConfig } from "./CustomTable";
 import useTableSort from "@/hook/useTableSort";
 import { TableSortTargetType } from "@/type/Table";
+import { SxProps, Theme } from "@mui/material";
 
 type Props<T> = {
   /** データ一覧 */
@@ -19,6 +20,32 @@ export const useCustomTable = <T extends object>({
   columns,
   initialTarget,
 }: Props<T>) => {
+  // UI関連
+  const bodyStyle = useMemo(
+    () => ({
+      textAlign: "center",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    }),
+    []
+  );
+  const headerStyle = useCallback((col: ColumnConfig<T>): SxProps<Theme> => {
+    const style: SxProps<Theme> = {
+      textAlign: "center",
+      pl:
+        col.labelProp === "sortable" ||
+        col.labelProp === "sortableAndFilterable"
+          ? 4
+          : 2,
+    };
+
+    if (col.width !== undefined) {
+      style.width = col.width;
+    }
+
+    return style;
+  }, []);
   const getSortTarget = useCallback(
     (
       a: T,
@@ -134,6 +161,10 @@ export const useCustomTable = <T extends object>({
   );
 
   return {
+    /** ボディ部分のスタイル */
+    bodyStyle,
+    /** ヘッダー部分のスタイル */
+    headerStyle,
     /** ソートが昇順か降順か */
     isAsc,
     /** ソート対象に選択されているかどうかを調べる */


### PR DESCRIPTION
# 変更点
- カスタムテーブルのUIを調整(style面中心)

# 詳細
- テーブル全体
  - 固定ヘッダーの設定を追加
    - 引数にstickyheaderを与えることで固定可能
  - tableLayout:"fixed"を与えて幅を固定化(colConfigに与えたwidthに依存)
- ヘッダー
  - colConfigに依存して計算してstyleを設定
    - textAlignで中央添え
    - ソート可能な場合はソートアイコンの都合でちょっと左にずれるので、paddingLeftを増加させることでタイトルのテキストを中央に寄せる
      - labelPropの内容で分岐して判断
    - widthは存在する場合のみ指定
- ボディ
  - メモ化して渡す
    - textAlignで中央添え
    - overflow: "hidden",textOverflow: "ellipsis",whiteSpace: "nowrap",の3つで文章が長い場合は"..."を使って省略表示