### PR TITLE
パラメータの取得方法をクライアント側の設定に合わせて修正

### DIFF
--- a/my-app/src/app/work-log/task/[id]/page.tsx
+++ b/my-app/src/app/work-log/task/[id]/page.tsx
@@ -15,17 +15,11 @@ import TaskEditDialog from "./dialog/task-edit/TaskEditDialog";
 import useDialog from "@/hook/useDialog";
 import CompleteConfirmDialog from "../../../../component/dialog/complete-confirm/CompleteConfirmDialog";
 import ConfirmDeleteDialog from "@/component/dialog/ConfirmDeleteDialog/ConfirmDeleteDialog";
-import { use } from "react";
 
-type Props = {
-  /** パスパラメータ(ページ呼び出し時に自動的に取得) */
-  params: Promise<{ id: string }>;
-};
 /**
  * タスク詳細ページ
  */
-export default function TaskDetailPage({ params }: Props) {
-  const { id } = use(params);
+export default function TaskDetailPage() {
   const {
     openError,
     onCloseError,
@@ -43,7 +37,7 @@ export default function TaskDetailPage({ params }: Props) {
     handleComplete,
     handleDelete,
     navigateCategoryPage,
-  } = useTaskDetailPage({ id });
+  } = useTaskDetailPage();
   const {
     open: openEdit,
     onClose: onCloseEdit,

--- a/my-app/src/app/work-log/task/[id]/useTaskDetailPage.ts
+++ b/my-app/src/app/work-log/task/[id]/useTaskDetailPage.ts
@@ -1,16 +1,13 @@
 import { localClient } from "@/lib/localClient";
-import { notFound, useRouter } from "next/navigation";
+import { notFound, useParams, useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import useSWR, { mutate } from "swr";
 
-type Props = {
-  /** パスパラメータのid(ページ呼び出し時に自動的に取得) */
-  id: string;
-};
 /**
  * タスク詳細ページのカスタムフック
  */
-export default function useTaskDetailPage({ id }: Props) {
+export default function useTaskDetailPage() {
+  const { id } = useParams<{ id: string }>();
   const [openError, setOpenError] = useState<boolean>(false);
   const onCloseError = useCallback(() => setOpenError(false), []);
   const router = useRouter();


### PR DESCRIPTION
タイトル通り

クライアントサイドではuseParamsでパラメータを取得されているのが推奨されているため、修正