### PR TITLE
日付ページでデータを受け取る際に新しいものが先頭に来るように調整(ソート時に新しいものが先頭にくるように)

### DIFF
--- a/my-app/src/lib/local-services/dailyDetailService.ts
+++ b/my-app/src/lib/local-services/dailyDetailService.ts
@@ -100,8 +100,8 @@ export const getDailyDetailData = async (date: string) => {
   });
   return {
     date,
-    taskList: tasks,
-    memoList: memos,
+    taskList: tasks.reverse(), // 新しいものが先頭にくるように
+    memoList: memos.reverse(), // 新しいものが先頭に来るように
   };
 };
 


### PR DESCRIPTION
タイトル通り
reverse()でidが大きいものが先頭にくるように調整
ソート時にもなるべくidが大きいものがくるようになるはず