### PR TITLE
テーブルの高さを指定して固定化

### DIFF
--- a/my-app/src/app/work-log/daily/table/DailyTable.tsx
+++ b/my-app/src/app/work-log/daily/table/DailyTable.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Stack, Typography } from "@mui/material";
+import { Stack, TableContainer, Typography } from "@mui/material";
 import DailyTableLogic from "./logic";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import CustomMenuWrapper from "@/component/menu/CustomMenuWrapper/CustomMenuWrapper";
@@ -80,14 +80,16 @@ const DailyTable = memo(function DailyTable() {
   );
   return (
     <>
-      <CustomTable<DateSummary & { id: number }>
-        data={itemList}
-        columns={columnsConfig}
-        stickyHeader
-        loading={isLoading}
-        initialTarget={"日付"}
-        onClickRow={handleNavigateSelectedDay}
-      />
+      <TableContainer sx={{ height: "70vh" }}>
+        <CustomTable<DateSummary & { id: number }>
+          data={itemList}
+          columns={columnsConfig}
+          stickyHeader
+          loading={isLoading}
+          initialTarget={"日付"}
+          onClickRow={handleNavigateSelectedDay}
+        />
+      </TableContainer>
       {/** カスタムメニューの面々   */}
       <CustomMenuWrapper
         logic={{ handleMouseEnter, handleMouseLeave, openTargetIdRef, ...prev }}


### PR DESCRIPTION
# 変更点
- 日付一覧ページ　テーブルの高さを固定化

# 詳細
- ビューポートに合わせた高さを指定することでテーブルサイズを固定化