### PR TITLE
日付データをとったのちに割合が高い順にソートしてから渡すように修正

### DIFF
--- a/my-app/src/lib/local-services/dailySummaryService.ts
+++ b/my-app/src/lib/local-services/dailySummaryService.ts
@@ -218,8 +218,18 @@ export const getDailySummaryDetailData = async ({
       percent: `${categoryPercent}%`,
     };
   });
+  // カテゴリのパーセントが高い順にソート
+  const sortedCategory = categoryList.sort(
+    (a, b) => parseFloat(b.percent) - parseFloat(a.percent)
+  );
 
-  dateSummaryDetail.categoryList = categoryList;
+  // taskListをパーセントが高い順にソート
+  sortedCategory.forEach((category) => {
+    category.taskList.sort(
+      (a, b) => parseFloat(b.percent) - parseFloat(a.percent)
+    );
+  });
+  dateSummaryDetail.categoryList = sortedCategory;
 
   // memoListを作成
   dateSummaryDetail.memoList = rawData.flatMap((log) =>


### PR DESCRIPTION
# 詳細

## 問題点
- 日付ダイアログについて
  - データ取得時
    - カテゴリの順番がランダムだった点
      - 稼働時間が少ないカテゴリが上位に表示される場合がある
    - タスクの順番がランダムだった点
      - 稼働時間の少ないタスクが上位に表示される場合がある

## 原因
- データ取得時
  - 日付内タスク/カテゴリをid順に取得して整形して渡す
  - これによって表示されるデータはidに依存して順番に表示されることになる
  - そのため、稼働状況とは関係なく表示されることになっていた

## 解決
- データ取得時
  - Array.sortでpercentの値でソートしてから渡すように変更
    - categoryは直接、taskは整形後にcategoryListをforEachでtaskListをArray.sortでソート