### PR TITLE
ログを削除する際に関連するメモも全て削除するように変更

### DIFF
--- a/my-app/src/lib/local-services/dailyDetailService.ts
+++ b/my-app/src/lib/local-services/dailyDetailService.ts
@@ -184,6 +184,8 @@ export const deleteTaskLog = async (id: number) => {
   // データを削除
   await db.taskLogs.delete(id);
 
+  // 関連するメモも削除
+  await db.memos.where("taskLogId").equals(id).delete();
   // 必要に応じて元タスクの最終更新日を引き下げる
   await adjustTaskActivityDatesIfRemoved(data.date, data.taskId);
 


### PR DESCRIPTION
タイトル通り

# 詳細
## 問題点
- ログを削除する場合に関連するメモデータが残る
- これはタスクページで表示されることはない(taskId -> log -> memoのように取得するため、logがないとメモは参照できない)
- そのため、参照されることのないデータが残存することになる

## 対処
- ログ削除時に関連するメモも削除する処理を追加

# 今後について
- 削除時に確認させる旨が必要
  - メモがあるならそれも消える旨を確認させる
    - 確認させるためのダイアログ
      - メモタイトルを列挙して表示
    - 問い合わせるエンドポイント
      - 上記のタイトルを取得する or nullで分岐させる
  - 上記二つを実装して対応予定