### PR TITLE
Feature/confirm delete include memos dialog

### DIFF
--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialog.stories.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialog.stories.tsx
@@ -1,9 +1,15 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
 
-import ConfirmDeleteIncludeMemosDialog from './ConfirmDeleteIncludeMemosDialog';
+import ConfirmDeleteIncludeMemosDialog from "./ConfirmDeleteIncludeMemosDialog";
 
 const meta = {
   component: ConfirmDeleteIncludeMemosDialog,
+  args: {
+    open: true,
+    onClose: () => {},
+    onDelete: async () => {},
+    memoTitles: ["メモ1", "メモ2", "メモ3"],
+  },
 } satisfies Meta<typeof ConfirmDeleteIncludeMemosDialog>;
 
 export default meta;
@@ -11,5 +17,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {}
+  args: {},
 };

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialog.tsx
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialog.tsx
@@ -8,12 +8,32 @@ import {
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { memo } from "react";
+import { ConfirmDeleteIncludeMemosDialogLogic } from "./ConfirmDeleteIncludeMemosDialogLogic";
+
+type Props = {
+  /** ダイアログ開閉状態 */
+  open: boolean;
+  /** ダイアログを閉じるハンドラー */
+  onClose: () => void;
+  /** 削除ハンドラー */
+  onDelete: () => Promise<void>;
+  /** メモタイトル一覧 */
+  memoTitles: string[];
+};
 
 const ConfirmDeleteIncludeMemosDialog = memo(
-  function ConfirmDeleteIncludeMemosDialog() {
-    const memoTitles = ["メモ1", "メモ2", "メモ3"];
+  function ConfirmDeleteIncludeMemosDialog({
+    open,
+    onClose,
+    onDelete,
+    memoTitles,
+  }: Props) {
+    const { onClickDelete } = ConfirmDeleteIncludeMemosDialogLogic({
+      onClose,
+      onDelete,
+    });
     return (
-      <Dialog open={true} onClose={() => {}}>
+      <Dialog open={open} onClose={onClose}>
         <DialogTitle>
           <WarningAmberIcon color="warning" sx={{ pr: 1 }} />
           ログに関連したメモが存在します
@@ -28,8 +48,12 @@ const ConfirmDeleteIncludeMemosDialog = memo(
           本当に削除しますか?
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => {}}>キャンセル</Button>
-          <Button onClick={() => {}} color="error" startIcon={<DeleteIcon />}>
+          <Button onClick={onClose}>キャンセル</Button>
+          <Button
+            onClick={onClickDelete}
+            color="error"
+            startIcon={<DeleteIcon />}
+          >
             削除
           </Button>
         </DialogActions>

--- a/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialogLogic.ts
+++ b/my-app/src/app/work-log/daily/[date]/task-list/dialog/TaskEditDialog/ConfirmDeleteIncludeMemosDialog/ConfirmDeleteIncludeMemosDialogLogic.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+
+type Props = {
+  /** ダイアログを閉じるハンドラー */
+  onClose: () => void;
+  /** 削除ハンドラー */
+  onDelete: () => Promise<void>;
+};
+
+/**
+ * メモ削除確認ダイアログのロジック
+ */
+export const ConfirmDeleteIncludeMemosDialogLogic = ({
+  onClose,
+  onDelete,
+}: Props) => {
+  const onClickDelete = useCallback(async () => {
+    await onDelete();
+    onClose();
+  }, [onClose, onDelete]);
+
+  return {
+    /** 削除ハンドラー(削除して閉じる) */
+    onClickDelete,
+  };
+};


### PR DESCRIPTION
# 変更点
- メモが存在するログを削除時に表示する確認ダイアログを作成

# 詳細
- UI
  - メモのタイトル一覧をリストで表示
  - メモも消える旨を表示
- ロジック
  - 引数
    - 自身の開閉関連を受け取り
    - 表示するメモタイトルの一覧を受け取り
    - 非同期の削除ロジックを受け取り
  - 内部ロジック
    - 削除ロジックと自身を閉じるロジックを組み合わせて削除をクリック時のハンドラーを作成
    - 削除をawaitして完了後に閉じる処理