### PR TITLE
タスク一覧取得時に更新日が新しいものから先頭にして取得するように変更

### DIFF
--- a/my-app/src/lib/local-services/taskService.ts
+++ b/my-app/src/lib/local-services/taskService.ts
@@ -23,6 +23,11 @@ export const getTaskOptions = async ({ categoryId }: TaskOptionQuery) => {
   const data = await db.tasks.where("categoryId").equals(categoryId).toArray();
   const result: TaskOption[] = data
     .filter((v) => v.progress !== 100) // 完了済みを除外する
+    .sort((a, b) => {
+      const aDate = a?.lastActivityDate ?? "";
+      const bDate = b?.lastActivityDate ?? "";
+      return bDate.localeCompare(aDate);
+    })
     .map((v) => {
       return { id: v.id, name: v.name }; // 必要なパラメータだけ取得
     });


### PR DESCRIPTION
タイトル通り

BEで取得時に更新日順にsortして渡すように変更(更新日がない場合は後ろにくるように)