### PR TITLE
ソートロジック追加

### DIFF
--- a/my-app/src/lib/local-services/taskService.ts
+++ b/my-app/src/lib/local-services/taskService.ts
@@ -406,6 +406,11 @@ export const getLastMonthTaskActivities = async () => {
           (hours) => hours.id === item.id
         )!.hours;
         return { name: taskName, hours: `${hours}(h)` };
+      })
+      .sort((a, b) => {
+        const aHours = parseFloat(a.hours.split("(")[0]);
+        const bHours = parseFloat(b.hours.split("(")[0]);
+        return bHours - aHours;
       });
     return {
       id,


### PR DESCRIPTION
データ取得時に稼働時間順にソートしてから受け渡しするように変更
これで円グラフでツールチップ上でタスクが稼働時間順に表示される