### PR TITLE
グローバルなロードUI作成(ページ遷移時のユーザーへのレスポンスのため)

### DIFF
--- a/my-app/src/app/loading.tsx
+++ b/my-app/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { CircularProgress } from "@mui/material";
+
+export default function GlobalLoading() {
+  return <CircularProgress />;
+}


### PR DESCRIPTION
タイトル通り

ページ遷移時にページ切り替わりまでのラグが「ロード中」か「クリックを認識してない」かわかりづらかったので

効果があるかは不明　効果あればロードUIが即座に表示されるようになるはず